### PR TITLE
Migrated netty-transports configuration to YAML 

### DIFF
--- a/http/netty/component/etc/conf/netty-transports.yml
+++ b/http/netty/component/etc/conf/netty-transports.yml
@@ -1,0 +1,54 @@
+################################################################################
+#   Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+listenerConfigurations:
+ -
+  id: "jaxrs-http"
+  host: "127.0.0.1"
+  port: 7777
+  bossThreadPoolSize: 2
+  workerThreadPoolSize: 250
+  execHandlerThreadPoolSize: 60
+ -
+  id: "jaxrs-https"
+  host: "127.0.0.1"
+  port: 8888
+  bossThreadPoolSize: 2
+  workerThreadPoolSize: 250
+  execHandlerThreadPoolSize: 60
+  scheme: https
+  keyStoreFile: "repository/resources/security/cert.jks"
+  keyStorePass: secret
+  certPass: secret
+ -
+  id: "netty-gw"
+  host: "0.0.0.0"
+  port: 9090
+  bossThreadPoolSize: 4
+  workerThreadPoolSize: 8
+  execHandlerThreadPoolSize: 60
+  parameters:
+    -
+     name: "disruptor.wait.strategy"
+     value: PHASED_BACKOFF
+    -
+     name: "disruptor.buffer.size"
+     value: 1
+    -
+     name: "disruptor.count"
+     value: 1
+    -
+     name: "disruptor.eventhandler.count"
+     value: 1

--- a/http/netty/component/src/main/java/org/wso2/carbon/transport/http/netty/internal/NettyTransportActivator.java
+++ b/http/netty/component/src/main/java/org/wso2/carbon/transport/http/netty/internal/NettyTransportActivator.java
@@ -22,7 +22,7 @@ import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.wso2.carbon.kernel.transports.CarbonTransport;
 import org.wso2.carbon.transport.http.netty.internal.config.ListenerConfiguration;
-import org.wso2.carbon.transport.http.netty.internal.config.TransportConfigurationBuilder;
+import org.wso2.carbon.transport.http.netty.internal.config.YAMLTransportConfigurationBuilder;
 import org.wso2.carbon.transport.http.netty.listener.NettyListener;
 
 import java.util.HashSet;
@@ -48,7 +48,7 @@ public class NettyTransportActivator implements BundleActivator {
     private Set<NettyListener> createNettyListeners() {
         Set<NettyListener> listeners = new HashSet<>();
         Set<ListenerConfiguration> listenerConfigurations =
-                TransportConfigurationBuilder.build().getListenerConfigurations();
+                YAMLTransportConfigurationBuilder.build().getListenerConfigurations();
         for (ListenerConfiguration listenerConfiguration : listenerConfigurations) {
             listeners.add(new NettyListener(listenerConfiguration));
         }

--- a/http/netty/component/src/main/java/org/wso2/carbon/transport/http/netty/internal/TransportServiceCapabilityProvider.java
+++ b/http/netty/component/src/main/java/org/wso2/carbon/transport/http/netty/internal/TransportServiceCapabilityProvider.java
@@ -3,7 +3,7 @@ package org.wso2.carbon.transport.http.netty.internal;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.kernel.startupresolver.CapabilityProvider;
 import org.wso2.carbon.kernel.transports.CarbonTransport;
-import org.wso2.carbon.transport.http.netty.internal.config.TransportConfigurationBuilder;
+import org.wso2.carbon.transport.http.netty.internal.config.YAMLTransportConfigurationBuilder;
 
 /**
  * Component which registers the CarbonTransport capability information.
@@ -22,6 +22,6 @@ public class TransportServiceCapabilityProvider implements CapabilityProvider {
 
     @Override
     public int getCount() {
-        return TransportConfigurationBuilder.build().getListenerConfigurations().size();
+        return YAMLTransportConfigurationBuilder.build().getListenerConfigurations().size();
     }
 }

--- a/http/netty/component/src/main/java/org/wso2/carbon/transport/http/netty/internal/config/YAMLTransportConfigurationBuilder.java
+++ b/http/netty/component/src/main/java/org/wso2/carbon/transport/http/netty/internal/config/YAMLTransportConfigurationBuilder.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.transport.http.netty.internal.config;
+
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.introspector.BeanAccess;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Parses &amp; creates the object model for the Netty transport yaml configuration file.
+ */
+public class YAMLTransportConfigurationBuilder {
+
+    public static final String NETTY_TRANSPORT_CONF = "transports.netty.conf";
+
+    /**
+     * Parses &amp; creates the object model for the Netty transport yaml configuration file.
+     *
+     * @return TransportsConfiguration
+     */
+    public static TransportsConfiguration build() {
+        TransportsConfiguration transportsConfiguration;
+        String nettyTransportsConfigFile =
+                System.getProperty(NETTY_TRANSPORT_CONF,
+                        "repository" + File.separator + "conf" + File.separator + "transports" +
+                                File.separator + "netty-transports.yml");
+        File file = new File(nettyTransportsConfigFile);
+        if (file.exists()) {
+            try (Reader in = new InputStreamReader(new FileInputStream(file), StandardCharsets.ISO_8859_1)) {
+                Yaml yaml = new Yaml();
+                yaml.setBeanAccess(BeanAccess.FIELD);
+                transportsConfiguration = yaml.loadAs(in, TransportsConfiguration.class);
+            } catch (IOException e) {
+                String msg = "Error while loading " + nettyTransportsConfigFile + " configuration file";
+                throw new RuntimeException(msg, e);
+            }
+        } else { // return a default config
+            transportsConfiguration = TransportsConfiguration.getDefault();
+        }
+        return transportsConfiguration;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${org.snakeyaml.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -243,6 +248,7 @@
         <slf4j.version>1.7.5</slf4j.version>
         <carbon.p2.plugin.version>2.0.0-alpha</carbon.p2.plugin.version>
         <carbon.transport.osgi.version>1.0.0.SNAPSHOT</carbon.transport.osgi.version>
+        <org.snakeyaml.version>1.16.0.wso2v1</org.snakeyaml.version>
     </properties>
 
 </project>


### PR DESCRIPTION
- Introduced YAMLTransportConfigurationBuilder.java to parse yaml configuration
- Introduced new yaml configuration file named netty-transports.yml
- Replaced the usage of TransportConfigurationBuilder.build() by YAMLTransportConfigurationBuilder.build() in NettyTransportActivator.java and TransportServiceCapabilityProvider.java
