### PR TITLE
Fix RejectedExecutionException exception issue of trying to reuse workerGroup and bossGroup when starting a transport after stopping it

### DIFF
--- a/http/netty/component/src/main/java/org/wso2/carbon/transport/http/netty/listener/NettyListener.java
+++ b/http/netty/component/src/main/java/org/wso2/carbon/transport/http/netty/listener/NettyListener.java
@@ -52,8 +52,6 @@ public class NettyListener extends CarbonTransport {
     public NettyListener(ListenerConfiguration nettyConfig) {
         super(nettyConfig.getId());
         this.nettyConfig = nettyConfig;
-        bossGroup = new NioEventLoopGroup(nettyConfig.getBossThreadPoolSize());
-        workerGroup = new NioEventLoopGroup(nettyConfig.getWorkerThreadPoolSize());
     }
 
     public void start() {
@@ -62,6 +60,8 @@ public class NettyListener extends CarbonTransport {
     }
 
     private void startTransport() {
+        bossGroup = new NioEventLoopGroup(nettyConfig.getBossThreadPoolSize());
+        workerGroup = new NioEventLoopGroup(nettyConfig.getWorkerThreadPoolSize());
         bootstrap = new ServerBootstrap();
         bootstrap.option(ChannelOption.SO_BACKLOG, 100);
         bootstrap.group(bossGroup, workerGroup)


### PR DESCRIPTION
Following is the issue:

osgi> listTransports
Transport Name: jaxrs-http   State: STARTED
osgi> 
osgi> 
osgi> stopTransport jaxrs-http
[2015-12-18 18:18:54,729]  INFO {org.wso2.carbon.transport.http.netty.listener.NettyListener} - Stopping Netty transport jaxrs-http on port 8080
osgi> 
osgi> 
osgi> [2015-12-18 18:18:59,155]  INFO {org.wso2.carbon.transport.http.netty.listener.NettyListener} - Netty transport jaxrs-http on port 8080 stopped successfully
osgi> 
osgi> listTransports
Transport Name: jaxrs-http   State: STOPPED
osgi> 
osgi> 
osgi> startTransport jaxrs-http
[2015-12-18 18:19:17,378]  INFO {org.wso2.carbon.transport.http.netty.listener.NettyListener} - Starting Netty Http Transport Listener
[2015-12-18 18:19:17,380]  WARN {io.netty.channel.AbstractChannel} - Force-closing a channel whose registration task was not accepted by an event loop: [id: 0xafe9e0b1] java.util.concurrent.RejectedExecutionException: event executor terminated
    at io.netty.util.concurrent.SingleThreadEventExecutor.reject(SingleThreadEventExecutor.java:706)
    at io.netty.util.concurrent.SingleThreadEventExecutor.addTask(SingleThreadEventExecutor.java:298)
    at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:689)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.register(AbstractChannel.java:421)
    at io.netty.channel.SingleThreadEventLoop.register(SingleThreadEventLoop.java:60)
    at io.netty.channel.SingleThreadEventLoop.register(SingleThreadEventLoop.java:48)
    at io.netty.channel.MultithreadEventLoopGroup.register(MultithreadEventLoopGroup.java:64)
    at io.netty.bootstrap.AbstractBootstrap.initAndRegister(AbstractBootstrap.java:315)
    at io.netty.bootstrap.AbstractBootstrap.doBind(AbstractBootstrap.java:271)
    at io.netty.bootstrap.AbstractBootstrap.bind(AbstractBootstrap.java:267)
    at org.wso2.carbon.transport.http.netty.listener.NettyListener.startTransport(NettyListener.java:81)
    at org.wso2.carbon.transport.http.netty.listener.NettyListener.start(NettyListener.java:61)
    at org.wso2.carbon.kernel.transports.CarbonTransport.startTransport(CarbonTransport.java:47)
    at org.wso2.carbon.kernel.transports.TransportManager.startTransport(TransportManager.java:46)
    at org.wso2.carbon.kernel.internal.transports.TransportMgtCommandProvider._startTransport(TransportMgtCommandProvider.java:58)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.eclipse.equinox.console.command.adapter.CommandProviderAdapter.main(CommandProviderAdapter.java:47)
    at org.eclipse.equinox.console.command.adapter.CommandProviderAdapter._main(CommandProviderAdapter.java:65)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.apache.felix.gogo.runtime.Reflective.invoke(Reflective.java:137)
    at org.apache.felix.gogo.runtime.CommandProxy.execute(CommandProxy.java:82)
    at org.apache.felix.gogo.runtime.Closure.executeCmd(Closure.java:477)
    at org.apache.felix.gogo.runtime.Closure.executeStatement(Closure.java:403)
    at org.apache.felix.gogo.runtime.Pipe.run(Pipe.java:108)
    at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:183)
    at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:120)
    at org.apache.felix.gogo.runtime.CommandSessionImpl.execute(CommandSessionImpl.java:89)
    at org.apache.felix.gogo.shell.Console.run(Console.java:62)
    at org.apache.felix.gogo.shell.Shell.console(Shell.java:203)
    at org.apache.felix.gogo.shell.Shell.gosh(Shell.java:128)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.apache.felix.gogo.runtime.Reflective.invoke(Reflective.java:137)
    at org.apache.felix.gogo.runtime.CommandProxy.execute(CommandProxy.java:82)
    at org.apache.felix.gogo.runtime.Closure.executeCmd(Closure.java:477)
    at org.apache.felix.gogo.runtime.Closure.executeStatement(Closure.java:403)
    at org.apache.felix.gogo.runtime.Pipe.run(Pipe.java:108)
    at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:183)
    at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:120)
    at org.apache.felix.gogo.runtime.CommandSessionImpl.execute(CommandSessionImpl.java:89)
    at org.apache.felix.gogo.shell.Activator.run(Activator.java:75)
    at java.lang.Thread.run(Thread.java:745)

gogo: RejectedExecutionException: event executor terminated
osgi> 
