### PR TITLE
Fixed: Requests hanging on httpContentQueue.take() when message is already built

### DIFF
--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/HTTPCarbonMessage.java
@@ -111,7 +111,7 @@ public class HTTPCarbonMessage extends CarbonMessage {
         while (!isEndOfMessageProcessed) {
             try {
                 HttpContent httpContent = httpContentQueue.take();
-                if (httpContent instanceof LastHttpContent) {
+                if ((httpContent instanceof LastHttpContent) || (isEndOfMsgAdded() && httpContentQueue.isEmpty())) {
                     isEndOfMessageProcessed = true;
                 }
                 contentList.add(httpContent);


### PR DESCRIPTION
When the message is already built and copied back to httpContentQueue, there won't be any LastHttpContent message segment. Therefore it caused an issue, and made the request hang in httpContentQueue.take()