### PR TITLE
Change the existing carbon-transport to register multiple CarbonTrans…

### DIFF
--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HTTPTransportContextHolder.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HTTPTransportContextHolder.java
@@ -18,6 +18,7 @@
  */
 package org.wso2.carbon.transport.http.netty.internal;
 
+import io.netty.channel.EventLoopGroup;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +42,24 @@ public class HTTPTransportContextHolder {
     private HandlerExecutor handlerExecutor;
     private Map<String, ListenerConfiguration> listenerConfigurations = new HashMap<>();
     private TransportListenerManager manager;
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+
+    public EventLoopGroup getBossGroup() {
+        return bossGroup;
+    }
+
+    public void setBossGroup(EventLoopGroup bossGroup) {
+        this.bossGroup = bossGroup;
+    }
+
+    public EventLoopGroup getWorkerGroup() {
+        return workerGroup;
+    }
+
+    public void setWorkerGroup(EventLoopGroup workerGroup) {
+        this.workerGroup = workerGroup;
+    }
 
     public ListenerConfiguration getListenerConfiguration(String id) {
         return listenerConfigurations.get(id);

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/TransportServiceCapabilityProvider.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/TransportServiceCapabilityProvider.java
@@ -22,6 +22,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.kernel.startupresolver.CapabilityProvider;
+import org.wso2.carbon.transport.http.netty.config.YAMLTransportConfigurationBuilder;
 
 /**
  * Component which registers the CarbonTransport capability information.
@@ -42,6 +43,6 @@ public class TransportServiceCapabilityProvider implements CapabilityProvider {
     @Override
     public int getCount() {
         //Only one Listener configuration is needed for server startup.
-        return 1;
+        return YAMLTransportConfigurationBuilder.build().getListenerConfigurations().size();
     }
 }


### PR DESCRIPTION
…port for multiple listener configs
In MSF4J we need to register multiple CarabonTransport when multiple listener configs exist. This PR will register multiple CarabonTransport for that but sharing the same boss and worker pool.