### PR TITLE
HTTP/2 Transport Support

### DIFF
--- a/http/netty/components/org.wso2.carbon.transport.http.netty/pom.xml
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/pom.xml
@@ -69,6 +69,10 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.wso2.carbon</groupId>

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/pom.xml
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/pom.xml
@@ -73,6 +73,10 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.wso2.carbon</groupId>

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Constants.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Constants.java
@@ -183,6 +183,11 @@ public final class Constants {
 
     public static final String LOCALHOST = "localhost";
 
+    // HTTP2 Related Parameters
+    public static final String UPGRADE_RESPONSE_HEADER = "http-to-http2-upgrade";
+    public static final String HTTP2_VERSION = "HTTP/2.0";
+    public static final String STREAM_ID = "STREAM_ID";
+
     private Constants() {
     }
 

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/ssl/SSLHandlerFactory.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/ssl/SSLHandlerFactory.java
@@ -18,8 +18,16 @@
  */
 package org.wso2.carbon.transport.http.netty.common.ssl;
 
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
-
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -39,6 +47,7 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
@@ -52,6 +61,8 @@ public class SSLHandlerFactory {
     private final SSLContext serverContext;
     private SSLConfig sslConfig;
     private boolean needClientAuth;
+    private KeyManagerFactory kmf;
+    private TrustManagerFactory tmf;
 
 
     public SSLHandlerFactory(SSLConfig sslConfig) {
@@ -63,7 +74,7 @@ public class SSLHandlerFactory {
         try {
             KeyStore ks = getKeyStore(sslConfig.getKeyStore(), sslConfig.getKeyStorePass());
             // Set up key manager factory to use our key store
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
+            kmf = KeyManagerFactory.getInstance(algorithm);
             KeyManager[] keyManagers = null;
             if (ks != null) {
                 kmf.init(ks, sslConfig.getCertPass() != null ?
@@ -75,7 +86,7 @@ public class SSLHandlerFactory {
             if (sslConfig.getTrustStore() != null) {
                 this.needClientAuth = true;
                 KeyStore tks = getKeyStore(sslConfig.getTrustStore(), sslConfig.getTrustStorePass());
-                TrustManagerFactory tmf = TrustManagerFactory.getInstance(algorithm);
+                tmf = TrustManagerFactory.getInstance(algorithm);
                 tmf.init(tks);
                 trustManagers = tmf.getTrustManagers();
             }
@@ -128,5 +139,35 @@ public class SSLHandlerFactory {
             sslParameters.setServerNames(new ArrayList(Arrays.asList(sslConfig.getSniMatchers())));
         }
         return new SslHandler(engine);
+    }
+
+    /**
+     * This method will provide netty ssl context which supports HTTP2 over TLS using
+     * Application Layer Protocol Negotiation (ALPN)
+     * @return instance of {@link SslContext}
+     * @throws SSLException
+     */
+    public SslContext createHttp2TLSContext() throws SSLException {
+
+        SslProvider provider = OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK;
+        return SslContextBuilder.forServer(this.getKeyManagerFactory())
+                .trustManager(this.getTrustStoreFactory())
+                .sslProvider(provider)
+                .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                .clientAuth(needClientAuth ? ClientAuth.REQUIRE : ClientAuth.NONE)
+                .applicationProtocolConfig(new ApplicationProtocolConfig(
+                        ApplicationProtocolConfig.Protocol.ALPN,
+                        ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+                        ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                        ApplicationProtocolNames.HTTP_2,
+                        ApplicationProtocolNames.HTTP_1_1)).build();
+    }
+
+    public KeyManagerFactory getKeyManagerFactory() {
+        return kmf;
+    }
+
+    public TrustManagerFactory getTrustStoreFactory() {
+        return tmf;
     }
 }

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/config/ListenerConfiguration.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/config/ListenerConfiguration.java
@@ -60,6 +60,9 @@ public class ListenerConfiguration {
     private String scheme = "http";
 
     @XmlAttribute
+    private boolean http2TLS = false;
+
+    @XmlAttribute
     private String keyStoreFile;
 
     @XmlAttribute
@@ -149,6 +152,14 @@ public class ListenerConfiguration {
 
     public void setScheme(String scheme) {
         this.scheme = scheme;
+    }
+
+    public boolean isHttp2TLS() {
+        return http2TLS;
+    }
+
+    public void setHttp2TLS(boolean http2TLS) {
+        this.http2TLS = http2TLS;
     }
 
     public List<Parameter> getParameters() {

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPProtocolNegotiationHandler.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPProtocolNegotiationHandler.java
@@ -17,6 +17,8 @@
 */
 package org.wso2.carbon.transport.http.netty.listener;
 
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpContentCompressor;
@@ -88,6 +90,13 @@ public class HTTPProtocolNegotiationHandler extends ApplicationProtocolNegotiati
         }
 
         throw new IllegalStateException("unknown protocol: " + protocol);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        if (ctx != null && ctx.channel().isActive()) {
+            ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+        }
     }
 }
 

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPProtocolNegotiationHandler.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPProtocolNegotiationHandler.java
@@ -1,0 +1,89 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.transport.http.netty.listener;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpContentCompressor;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
+import io.netty.handler.stream.ChunkedWriteHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
+import org.wso2.carbon.transport.http.netty.config.RequestSizeValidationConfiguration;
+import org.wso2.carbon.transport.http.netty.listener.http2.HTTP2SourceHandlerBuilder;
+import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManager;
+
+import static io.netty.handler.logging.LogLevel.DEBUG;
+
+/**
+ * {@code HTTPProtocolNegotiationHandler}  negotiates with the client if HTTP2 or HTTP is going to be used. Once
+ * decided, the Netty pipeline is setup with the correct handlers for the selected protocol.
+ */
+public class HTTPProtocolNegotiationHandler extends ApplicationProtocolNegotiationHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(HTTPProtocolNegotiationHandler.class);
+    private static final Http2FrameLogger logger = new Http2FrameLogger(DEBUG, HTTPProtocolNegotiationHandler.class);
+    protected ConnectionManager connectionManager;
+    protected ListenerConfiguration listenerConfiguration;
+
+    protected HTTPProtocolNegotiationHandler(ConnectionManager connectionManager, ListenerConfiguration
+            listenerConfiguration) {
+        super(ApplicationProtocolNames.HTTP_1_1);
+        this.listenerConfiguration = listenerConfiguration;
+        this.connectionManager = connectionManager;
+    }
+
+    @Override
+    protected void configurePipeline(ChannelHandlerContext ctx, String protocol) throws Exception {
+        ChannelPipeline p = ctx.pipeline();
+        if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
+            ctx.pipeline().addLast("http2-handler", new HTTP2SourceHandlerBuilder(connectionManager,
+                    listenerConfiguration).build());
+            return;
+        }
+
+        if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
+
+            p.addLast("encoder", new HttpResponseEncoder());
+            if (RequestSizeValidationConfiguration.getInstance().isHeaderSizeValidation()) {
+                p.addLast("decoder", new CustomHttpRequestDecoder());
+            } else {
+                p.addLast("decoder", new HttpRequestDecoder());
+            }
+            if (RequestSizeValidationConfiguration.getInstance().isRequestSizeValidation()) {
+                p.addLast("custom-aggregator", new CustomHttpObjectAggregator());
+            }
+            p.addLast("compressor", new HttpContentCompressor());
+            p.addLast("chunkWriter", new ChunkedWriteHandler());
+            try {
+                p.addLast("handler", new SourceHandler(connectionManager, listenerConfiguration));
+            } catch (Exception e) {
+                log.error("Cannot Create SourceHandler ", e);
+            }
+            return;
+        }
+
+        throw new IllegalStateException("unknown protocol: " + protocol);
+    }
+}
+

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPProtocolNegotiationHandler.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPProtocolNegotiationHandler.java
@@ -54,14 +54,18 @@ public class HTTPProtocolNegotiationHandler extends ApplicationProtocolNegotiati
     }
 
     @Override
+    /**
+     *  Configure pipeline after SSL handshake
+     */
     protected void configurePipeline(ChannelHandlerContext ctx, String protocol) throws Exception {
         ChannelPipeline p = ctx.pipeline();
+        // handles pipeline for HTTP/2 requests after SSL handshake
         if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
             ctx.pipeline().addLast("http2-handler", new HTTP2SourceHandlerBuilder(connectionManager,
                     listenerConfiguration).build());
             return;
         }
-
+        // handles pipeline for HTTP/1 requests after SSL handshake
         if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
 
             p.addLast("encoder", new HttpResponseEncoder());

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPProtocolNegotiationHandler.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPProtocolNegotiationHandler.java
@@ -15,7 +15,7 @@
 * specific language governing permissions and limitations
 * under the License.
 */
-package org.wso2.carbon.transport.http.netty.listener.http2;
+package org.wso2.carbon.transport.http.netty.listener;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
@@ -32,9 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.carbon.transport.http.netty.config.RequestSizeValidationConfiguration;
-import org.wso2.carbon.transport.http.netty.listener.CustomHttpObjectAggregator;
-import org.wso2.carbon.transport.http.netty.listener.CustomHttpRequestDecoder;
-import org.wso2.carbon.transport.http.netty.listener.SourceHandler;
+import org.wso2.carbon.transport.http.netty.listener.http2.HTTP2SourceHandlerBuilder;
 import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManager;
 
 import static io.netty.handler.logging.LogLevel.DEBUG;

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
@@ -100,10 +100,10 @@ public class HTTPServerChannelInitializer extends ChannelInitializer<SocketChann
                 // Construct ssl context with ALPN configuration
                 SslContext sslContext = new SSLHandlerFactory(listenerConfiguration.getSslConfig())
                         .createHttp2TLSContext();
-                // ALPN handler will be added to find http protocol version
+                // ALPN handler will be added to decide http protocol version
                 configureHttp2upgrade(ch, listenerConfiguration, sslContext);
             } else {
-                // If ALPN protocol has not been enables, HTTP will be used over SSL.
+                // If ALPN protocol has not been enabled, HTTP will be used over SSL.
                 SslHandler sslHandler = new SSLHandlerFactory(listenerConfiguration.getSslConfig()).create();
                 ch.pipeline().addLast("ssl", sslHandler);
                 // Configure the pipeline handlers for HTTP after ssl handshake.

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.carbon.transport.http.netty.config.RequestSizeValidationConfiguration;
 import org.wso2.carbon.transport.http.netty.config.TransportProperty;
 import org.wso2.carbon.transport.http.netty.listener.http2.HTTP2SourceHandlerBuilder;
+import org.wso2.carbon.transport.http.netty.listener.http2.HTTPProtocolNegotiationHandler;
 import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManager;
 
 import java.util.HashMap;

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
@@ -38,7 +38,6 @@ import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.carbon.transport.http.netty.config.RequestSizeValidationConfiguration;
 import org.wso2.carbon.transport.http.netty.config.TransportProperty;
 import org.wso2.carbon.transport.http.netty.listener.http2.HTTP2SourceHandlerBuilder;
-import org.wso2.carbon.transport.http.netty.listener.http2.HTTPProtocolNegotiationHandler;
 import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManager;
 
 import java.util.HashMap;

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2ResponseCallback.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2ResponseCallback.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.HttpConversionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonCallback;
@@ -46,6 +47,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 public class HTTP2ResponseCallback implements CarbonCallback {
 
     private ChannelHandlerContext ctx;
+    // Stream id of the channel of initial request
     private int streamId;
     private static final Logger logger = LoggerFactory.getLogger(HTTP2ResponseCallback.class);
 
@@ -69,6 +71,7 @@ public class HTTP2ResponseCallback implements CarbonCallback {
         }
         Http2Headers http2Headers = new DefaultHttp2Headers().status(OK.codeAsText());
         cMsg.getHeaders().getAll().forEach(k -> http2Headers.set(k.getName().toLowerCase(), k.getValue()));
+        http2Headers.set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), Integer.toString(streamId));
 
         if (ctx.handler() instanceof HTTP2SourceHandler) {
             HTTP2SourceHandler http2SourceHandler = (HTTP2SourceHandler) ctx.handler();
@@ -95,7 +98,7 @@ public class HTTP2ResponseCallback implements CarbonCallback {
                         }
                         break;
                     }
-                    http2SourceHandler.encoder().writeData(ctx, 3, httpContent.content(), 0, false,
+                    http2SourceHandler.encoder().writeData(ctx, streamId, httpContent.content(), 0, false,
                             ctx.newPromise());
                 }
 

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2ResponseCallback.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2ResponseCallback.java
@@ -1,0 +1,144 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.transport.http.netty.listener.http2;
+
+import com.sun.xml.internal.bind.v2.TODO;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Headers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.messaging.CarbonCallback;
+import org.wso2.carbon.messaging.CarbonMessage;
+import org.wso2.carbon.messaging.DefaultCarbonMessage;
+import org.wso2.carbon.messaging.MessageDataSource;
+import org.wso2.carbon.transport.http.netty.common.Constants;
+import org.wso2.carbon.transport.http.netty.internal.HTTPTransportContextHolder;
+import org.wso2.carbon.transport.http.netty.message.HTTPCarbonMessage;
+
+import java.nio.ByteBuffer;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+
+/**
+ * {@code HTTP2ResponseCallback} is the class implements {@code CarbonCallback} interface to process http2 message
+ * responses coming from message processor
+ */
+public class HTTP2ResponseCallback implements CarbonCallback {
+
+    private ChannelHandlerContext ctx;
+    private int streamId;
+    private static final Logger logger = LoggerFactory.getLogger(HTTP2ResponseCallback.class);
+
+
+    public HTTP2ResponseCallback(ChannelHandlerContext channelHandlerContext, int streamId) {
+
+        this.ctx = channelHandlerContext;
+        this.streamId = streamId;
+    }
+
+    public void done(CarbonMessage cMsg) {
+
+        handleResponsesWithoutContentLength(cMsg);
+        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+            HTTPTransportContextHolder.getInstance().getHandlerExecutor().executeAtSourceResponseReceiving(cMsg);
+        }
+        Http2Headers http2Headers = new DefaultHttp2Headers().status(OK.codeAsText());
+        cMsg.getHeaders().getAll().forEach(k -> http2Headers.set(k.getName().toLowerCase(), k.getValue()));
+
+        if (ctx.handler() instanceof HTTP2SourceHandler) {
+            HTTP2SourceHandler http2SourceHandler = (HTTP2SourceHandler) ctx.handler();
+            http2SourceHandler.encoder().writeHeaders(ctx, streamId, http2Headers, 0, false,
+                    ctx.newPromise());
+            // Full HTTP2 Request response
+            if (cMsg instanceof HTTPCarbonMessage) {
+                HTTPCarbonMessage nettyCMsg = (HTTPCarbonMessage) cMsg;
+                while (true) {
+                    if (nettyCMsg.isEndOfMsgAdded() && nettyCMsg.isEmpty()) {
+                        http2SourceHandler.encoder().writeData(ctx, streamId, LastHttpContent
+                                .EMPTY_LAST_CONTENT.content().retain(), 0, true, ctx
+                                .newPromise());
+                        break;
+                    }
+                    HttpContent httpContent = nettyCMsg.getHttpContent();
+                    if (httpContent instanceof LastHttpContent) {
+                        http2SourceHandler.encoder().writeData(ctx, streamId, httpContent.content()
+                                .retain(), 0, true, ctx.newPromise());
+                        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+                            HTTPTransportContextHolder.getInstance().getHandlerExecutor()
+                                    .executeAtSourceResponseSending(cMsg);
+                        }
+                        break;
+                    }
+                    http2SourceHandler.encoder().writeData(ctx, 3, httpContent.content(), 0, false,
+                            ctx.newPromise());
+                }
+            // HTTP2 Header Request response
+            } else if (cMsg instanceof DefaultCarbonMessage) {
+                DefaultCarbonMessage defaultCMsg = (DefaultCarbonMessage) cMsg;
+                while (true) {
+                    ByteBuffer byteBuffer = defaultCMsg.getMessageBody();
+                    ByteBuf bbuf = Unpooled.wrappedBuffer(byteBuffer);
+                    http2SourceHandler.encoder().writeData(ctx, streamId, bbuf.retain(), 0, false, ctx
+                            .newPromise());
+                    if (defaultCMsg.isEndOfMsgAdded() && defaultCMsg.isEmpty()) {
+                        http2SourceHandler.encoder().writeData(ctx, streamId, LastHttpContent
+                                .EMPTY_LAST_CONTENT.content().retain(), 0, true, ctx.newPromise());
+                        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+                            HTTPTransportContextHolder.getInstance().getHandlerExecutor().
+                                    executeAtSourceResponseSending(cMsg);
+                        }
+                        break;
+                    }
+                }
+            }
+            try {
+                http2SourceHandler.flush(ctx);
+            } catch (Http2Exception e) {
+                logger.error("Error occurred while sending response to client", e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Handles the response without content length
+     * @param cMsg
+     */
+    private void handleResponsesWithoutContentLength(CarbonMessage cMsg) {
+        if (cMsg.isAlreadyRead()) {
+            MessageDataSource messageDataSource = cMsg.getMessageDataSource();
+            if (messageDataSource != null) {
+                messageDataSource.serializeData();
+                cMsg.setEndOfMsgAdded(true);
+                cMsg.getHeaders().remove(Constants.HTTP_CONTENT_LENGTH);
+            } else {
+                logger.error("Message is already built but cannot find the MessageDataSource");
+            }
+        }
+        if (cMsg.getHeader(Constants.HTTP_TRANSFER_ENCODING) == null
+                && cMsg.getHeader(Constants.HTTP_CONTENT_LENGTH) == null) {
+            cMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(cMsg.getFullMessageLength()));
+
+        }
+    }
+}

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2ResponseCallback.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2ResponseCallback.java
@@ -17,7 +17,6 @@
 */
 package org.wso2.carbon.transport.http.netty.listener.http2;
 
-import com.sun.xml.internal.bind.v2.TODO;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -41,7 +40,7 @@ import java.nio.ByteBuffer;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
 /**
- * {@code HTTP2ResponseCallback} is the class implements {@code CarbonCallback} interface to process http2 message
+ * {@code HTTP2ResponseCallback} is the class implements {@link CarbonCallback} interface to process http2 message
  * responses coming from message processor
  */
 public class HTTP2ResponseCallback implements CarbonCallback {
@@ -50,7 +49,12 @@ public class HTTP2ResponseCallback implements CarbonCallback {
     private int streamId;
     private static final Logger logger = LoggerFactory.getLogger(HTTP2ResponseCallback.class);
 
-
+    /**
+     * Construct a new {@link HTTP2ResponseCallback} to process HTTP2 responses
+     *
+     * @param channelHandlerContext Channel context
+     * @param streamId              Stream Id
+     */
     public HTTP2ResponseCallback(ChannelHandlerContext channelHandlerContext, int streamId) {
 
         this.ctx = channelHandlerContext;
@@ -70,6 +74,7 @@ public class HTTP2ResponseCallback implements CarbonCallback {
             HTTP2SourceHandler http2SourceHandler = (HTTP2SourceHandler) ctx.handler();
             http2SourceHandler.encoder().writeHeaders(ctx, streamId, http2Headers, 0, false,
                     ctx.newPromise());
+
             // Full HTTP2 Request response
             if (cMsg instanceof HTTPCarbonMessage) {
                 HTTPCarbonMessage nettyCMsg = (HTTPCarbonMessage) cMsg;
@@ -93,7 +98,8 @@ public class HTTP2ResponseCallback implements CarbonCallback {
                     http2SourceHandler.encoder().writeData(ctx, 3, httpContent.content(), 0, false,
                             ctx.newPromise());
                 }
-            // HTTP2 Header Request response
+
+                // HTTP2 Header Request response
             } else if (cMsg instanceof DefaultCarbonMessage) {
                 DefaultCarbonMessage defaultCMsg = (DefaultCarbonMessage) cMsg;
                 while (true) {
@@ -121,8 +127,9 @@ public class HTTP2ResponseCallback implements CarbonCallback {
     }
 
     /**
-     * Handles the response without content length
-     * @param cMsg
+     * Handles the response without content length and set or remove headers based on carbon message
+     *
+     * @param cMsg Carbon Message
      */
     private void handleResponsesWithoutContentLength(CarbonMessage cMsg) {
         if (cMsg.isAlreadyRead()) {

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2SourceHandler.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2SourceHandler.java
@@ -1,0 +1,295 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.transport.http.netty.listener.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpServerUpgradeHandler;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Flags;
+import io.netty.handler.codec.http2.Http2FrameListener;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.util.AsciiString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.messaging.CarbonCallback;
+import org.wso2.carbon.messaging.CarbonMessageProcessor;
+import org.wso2.carbon.transport.http.netty.common.Constants;
+import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
+import org.wso2.carbon.transport.http.netty.internal.HTTPTransportContextHolder;
+import org.wso2.carbon.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManager;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+
+/**
+ *
+ * Class {@code HTTP2SourceHandler} will read the http2 binary frames sent from client through the channel
+ * and build carbon messages and sent to message processor.
+ */
+public final class HTTP2SourceHandler extends Http2ConnectionHandler implements Http2FrameListener {
+
+    private static final Logger log = LoggerFactory.getLogger(HTTP2SourceHandler.class);
+    private Map<Integer, HTTPCarbonMessage> streamIdRequestMap = new HashMap<>();
+    private ConnectionManager connectionManager;
+    private ListenerConfiguration listenerConfiguration;
+
+    HTTP2SourceHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                       Http2Settings initialSettings, ConnectionManager connectionManager, ListenerConfiguration
+                               listenerConfiguration) {
+        super(decoder, encoder, initialSettings);
+        this.listenerConfiguration = listenerConfiguration;
+        this.connectionManager = connectionManager;
+    }
+
+
+    /**
+     * This method handles the cleartext HTTP upgrade event. If an upgrade occurred, sends a simple response via HTTP/2
+     * on stream 1 (the stream specifically reserved for cleartext HTTP upgrade).
+     *
+     * @param ctx
+     * @param evt
+     * @throws Exception
+     */
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+
+        if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
+            // Write an HTTP/2 response to the upgrade request
+            Http2Headers headers =
+                    new DefaultHttp2Headers().status(OK.codeAsText())
+                            .set(new AsciiString(Constants.UPGRADE_RESPONSE_HEADER), new AsciiString("true"));
+            encoder().writeHeaders(ctx, 1, headers, 0, true, ctx.newPromise());
+        }
+        super.userEventTriggered(ctx, evt);
+
+    }
+
+    @Override
+    public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+        // Start the server connection Timer
+        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+
+            HTTPTransportContextHolder.getInstance().getHandlerExecutor()
+                    .executeAtSourceConnectionInitiation(Integer.toString(ctx.hashCode()));
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        super.exceptionCaught(ctx, cause);
+        ctx.close();
+        throw new Exception(cause.getMessage());
+    }
+
+    @Override
+    public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endOfStream)
+            throws Http2Exception {
+
+        HTTPCarbonMessage cMsg = streamIdRequestMap.get(streamId);
+        if (cMsg != null) {
+            cMsg.addHttpContent(new DefaultLastHttpContent(data.retain()));
+            if (endOfStream) {
+                cMsg.setEndOfMsgAdded(true);
+                if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+                    HTTPTransportContextHolder.getInstance().getHandlerExecutor().executeAtSourceRequestSending(cMsg);
+                }
+            }
+        }
+        return data.readableBytes() + padding;
+    }
+
+
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
+                              Http2Headers headers, int padding, boolean endOfStream) throws Http2Exception {
+
+        HTTPCarbonMessage cMsg = publishToMessageProcessor(streamId, headers, ctx);
+        if (endOfStream) {
+            cMsg.setEndOfMsgAdded(true);
+            if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+                HTTPTransportContextHolder.getInstance().getHandlerExecutor().executeAtSourceRequestSending(cMsg);
+            }
+        }
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency,
+                              short weight, boolean exclusive, int padding, boolean endOfStream) throws Http2Exception {
+        onHeadersRead(ctx, streamId, headers, padding, endOfStream);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        // Stop the connector timer
+        ctx.close();
+        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+            HTTPTransportContextHolder.getInstance().getHandlerExecutor()
+                    .executeAtSourceConnectionTermination(Integer.toString(ctx.hashCode()));
+        }
+        connectionManager.notifyChannelInactive();
+    }
+
+
+    /**
+     * Carbon Message is published to registered message processor and Message Processor should return transport
+     * thread immediately
+     *
+     * @param streamId
+     * @param headers
+     * @param ctx
+     * @return
+     */
+    private HTTPCarbonMessage publishToMessageProcessor(int streamId, Http2Headers headers, ChannelHandlerContext ctx) {
+        HTTPCarbonMessage cMsg = setupCarbonMessage(streamId, headers, ctx);
+        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+            HTTPTransportContextHolder.getInstance().getHandlerExecutor().executeAtSourceRequestReceiving(cMsg);
+        }
+
+        boolean continueRequest = true;
+
+        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+
+            continueRequest = HTTPTransportContextHolder.getInstance().getHandlerExecutor()
+                    .executeRequestContinuationValidator(cMsg, carbonMessage -> {
+                        CarbonCallback responseCallback = (CarbonCallback) cMsg
+                                .getProperty(org.wso2.carbon.messaging.Constants.CALL_BACK);
+                        responseCallback.done(carbonMessage);
+                    });
+
+        }
+        if (continueRequest) {
+            CarbonMessageProcessor carbonMessageProcessor = HTTPTransportContextHolder.getInstance()
+                    .getMessageProcessor();
+            if (carbonMessageProcessor != null) {
+                try {
+                    carbonMessageProcessor.receive(cMsg, new HTTP2ResponseCallback(ctx, streamId));
+                } catch (Exception e) {
+                    log.error("Error while submitting CarbonMessage to CarbonMessageProcessor", e);
+                }
+            } else {
+                log.error("Cannot find registered MessageProcessor for forward the message");
+            }
+        }
+
+        return cMsg;
+    }
+
+    /**
+     * Setup carbon message for HTTP2 request
+     * @param streamId
+     * @param headers
+     * @param ctx
+     * @return
+     */
+    protected HTTPCarbonMessage setupCarbonMessage(int streamId, Http2Headers headers, ChannelHandlerContext ctx) {
+
+        HTTPCarbonMessage cMsg = new HTTPCarbonMessage();
+        cMsg.setProperty(Constants.PORT, ((InetSocketAddress) ctx.channel().remoteAddress()).getPort());
+        cMsg.setProperty(Constants.HOST, ((InetSocketAddress) ctx.channel().remoteAddress()).getHostName());
+        cMsg.setProperty(Constants.HTTP_VERSION, Constants.HTTP2_VERSION);
+        cMsg.setProperty(org.wso2.carbon.messaging.Constants.LISTENER_PORT,
+                ((InetSocketAddress) ctx.channel().localAddress()).getPort());
+        cMsg.setProperty(org.wso2.carbon.messaging.Constants.LISTENER_INTERFACE_ID, listenerConfiguration.getId());
+        cMsg.setProperty(org.wso2.carbon.messaging.Constants.PROTOCOL, Constants.PROTOCOL_NAME);
+        if (listenerConfiguration.getSslConfig() != null) {
+            cMsg.setProperty(Constants.IS_SECURED_CONNECTION, true);
+        } else {
+            cMsg.setProperty(Constants.IS_SECURED_CONNECTION, false);
+        }
+        cMsg.setProperty(Constants.LOCAL_ADDRESS, ctx.channel().localAddress());
+        cMsg.setProperty(Constants.LOCAL_NAME, ((InetSocketAddress) ctx.channel().localAddress()).getHostName());
+        cMsg.setProperty(Constants.REMOTE_ADDRESS, ctx.channel().remoteAddress());
+        cMsg.setProperty(Constants.REMOTE_HOST, ((InetSocketAddress) ctx.channel().remoteAddress()).getHostName());
+        cMsg.setProperty(Constants.REMOTE_PORT, ((InetSocketAddress) ctx.channel().remoteAddress()).getPort());
+        ChannelHandler handler = ctx.handler();
+        cMsg.setProperty(Constants.CHANNEL_ID, ((HTTP2SourceHandler) handler).getListenerConfiguration().getId());
+        cMsg.setProperty(Constants.STREAM_ID, streamId);
+
+        if (headers.path() != null) {
+            cMsg.setProperty(Constants.TO, headers.path().toString());
+            cMsg.setProperty(Constants.REQUEST_URL, headers.path().toString());
+        }
+        if (headers.method() != null) {
+            cMsg.setProperty(Constants.HTTP_METHOD, headers.method().toString());
+        }
+        headers.forEach(k -> cMsg.setHeader(k.getKey().toString(), k.getValue().toString()));
+        streamIdRequestMap.put(streamId, cMsg);
+        return cMsg;
+    }
+
+    @Override
+    public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
+                               short weight, boolean exclusive) {
+    }
+
+    @Override
+    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) {
+    }
+
+    @Override
+    public void onSettingsAckRead(ChannelHandlerContext ctx) {
+    }
+
+    @Override
+    public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) {
+    }
+
+    @Override
+    public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) {
+    }
+
+    @Override
+    public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) {
+    }
+
+    @Override
+    public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+                                  Http2Headers headers, int padding) {
+    }
+
+    @Override
+    public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData) {
+    }
+
+    @Override
+    public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement) {
+    }
+
+    @Override
+    public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+                               Http2Flags flags, ByteBuf payload) {
+    }
+
+    public ListenerConfiguration getListenerConfiguration() {
+        return listenerConfiguration;
+    }
+
+
+}
+

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2SourceHandlerBuilder.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2SourceHandlerBuilder.java
@@ -1,0 +1,63 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.transport.http.netty.listener.http2;
+
+
+import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
+import io.netty.handler.codec.http2.DefaultHttp2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.codec.http2.Http2Settings;
+import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
+import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManager;
+
+import static io.netty.handler.logging.LogLevel.INFO;
+
+/**
+ * {@code HTTP2SourceHandlerBuilder} is used to build the http2 response handler with frame listener and connection
+ * manager.
+ */
+public final class HTTP2SourceHandlerBuilder
+        extends AbstractHttp2ConnectionHandlerBuilder<HTTP2SourceHandler, HTTP2SourceHandlerBuilder> {
+
+    private ConnectionManager connectionManager;
+    private ListenerConfiguration listenerConfiguration;
+    private static final Http2FrameLogger logger = new Http2FrameLogger(INFO, HTTP2SourceHandler.class);
+
+    public HTTP2SourceHandlerBuilder(ConnectionManager connectionManager, ListenerConfiguration listenerConfiguration) {
+        frameLogger(logger);
+        this.listenerConfiguration = listenerConfiguration;
+        this.connectionManager = connectionManager;
+    }
+
+    @Override
+    public HTTP2SourceHandler build() {
+        return super.build();
+    }
+
+    @Override
+    protected HTTP2SourceHandler build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                                       Http2Settings initialSettings) {
+        HTTP2SourceHandler handler = new HTTP2SourceHandler(decoder, encoder, initialSettings, connectionManager,
+                listenerConfiguration);
+        frameListener(handler);
+        connection(new DefaultHttp2Connection(true));
+        return handler;
+    }
+}

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2SourceHandlerBuilder.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2SourceHandlerBuilder.java
@@ -27,7 +27,7 @@ import io.netty.handler.codec.http2.Http2Settings;
 import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManager;
 
-import static io.netty.handler.logging.LogLevel.INFO;
+import static io.netty.handler.logging.LogLevel.DEBUG;
 
 /**
  * {@code HTTP2SourceHandlerBuilder} is used to build the http2 response handler with frame listener and connection
@@ -38,7 +38,7 @@ public final class HTTP2SourceHandlerBuilder
 
     private ConnectionManager connectionManager;
     private ListenerConfiguration listenerConfiguration;
-    private static final Http2FrameLogger logger = new Http2FrameLogger(INFO, HTTP2SourceHandler.class);
+    private static final Http2FrameLogger logger = new Http2FrameLogger(DEBUG, HTTP2SourceHandler.class);
 
     public HTTP2SourceHandlerBuilder(ConnectionManager connectionManager, ListenerConfiguration listenerConfiguration) {
         frameLogger(logger);

--- a/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTPProtocolNegotiationHandler.java
+++ b/http/netty/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTPProtocolNegotiationHandler.java
@@ -15,7 +15,7 @@
 * specific language governing permissions and limitations
 * under the License.
 */
-package org.wso2.carbon.transport.http.netty.listener;
+package org.wso2.carbon.transport.http.netty.listener.http2;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
@@ -32,7 +32,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.carbon.transport.http.netty.config.RequestSizeValidationConfiguration;
-import org.wso2.carbon.transport.http.netty.listener.http2.HTTP2SourceHandlerBuilder;
+import org.wso2.carbon.transport.http.netty.listener.CustomHttpObjectAggregator;
+import org.wso2.carbon.transport.http.netty.listener.CustomHttpRequestDecoder;
+import org.wso2.carbon.transport.http.netty.listener.SourceHandler;
 import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManager;
 
 import static io.netty.handler.logging.LogLevel.DEBUG;

--- a/http/netty/features/org.wso2.carbon.transport.http.netty.feature/pom.xml
+++ b/http/netty/features/org.wso2.carbon.transport.http.netty.feature/pom.xml
@@ -59,7 +59,14 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+        </dependency>
         <dependency>
             <groupId>commons-pool.wso2</groupId>
             <artifactId>commons-pool</artifactId>
@@ -144,6 +151,14 @@
                                 </bundle>
                                 <bundle>
                                     <symbolicName>io.netty.buffer</symbolicName>
+                                    <version>${netty.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>io.netty.codec-http2</symbolicName>
+                                    <version>${netty.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>io.netty.resolver</symbolicName>
                                     <version>${netty.version}</version>
                                 </bundle>
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,16 @@
                 <version>${netty.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.core</artifactId>
                 <version>${org.wso2.carbon.core.version}</version>
@@ -227,7 +237,7 @@
         <org.wso2.carbon.core.version>5.1.0</org.wso2.carbon.core.version>
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
 
-        <netty.version>4.0.30.Final</netty.version>
+        <netty.version>4.1.8.Final</netty.version>
         <netty.package.import.version.range>[4.0.30, 5.0.0)</netty.package.import.version.range>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <org.wso2.carbon.core.version>5.1.0</org.wso2.carbon.core.version>
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
 
-        <netty.version>4.1.8.Final</netty.version>
+        <netty.version>4.1.7.Final</netty.version>
         <netty.package.import.version.range>[4.0.30, 5.0.0)</netty.package.import.version.range>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>


### PR DESCRIPTION
**HTTP/2**
HTTP/2 is introduced to address some drawbacks of HTTP/1 versions with features of Binary information exchange, compressed headers,multiplexing, Server Push .

**Implementation**
This pull request contains the initial implementation required to support HTTP/2 for current HTTP server connector including following.

1. Netty upgrade to 4.1.x (Required for HTTP/2)
2. HTTP/2  and HTTP/2 over TLS support
3. HTTP/2 multiplexing

**Todo List**

- [ ] HTTP/2 Transport Sender
- [ ] Unit test with sender and HTTP server connector
