### PR TITLE
WebSocket Error handler for Transport

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/WebSocketServerConnectorErrorHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/WebSocketServerConnectorErrorHandler.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.transport.http.netty.listener;
+
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.messaging.CarbonCallback;
+import org.wso2.carbon.messaging.CarbonMessage;
+import org.wso2.carbon.messaging.ServerConnectorErrorHandler;
+import org.wso2.carbon.transport.http.netty.common.Constants;
+
+/**
+ * Error handler for WebSocket protocol.
+ * After the handshake, in WebSocket Protocol there is no explicit way of handling error and simply
+ * informing the client about it. So for debugging purposes this error handler can be used.
+ */
+@Component(
+        name = "ws.server.connector.error.handler",
+        immediate = true,
+        service = ServerConnectorErrorHandler.class)
+public class WebSocketServerConnectorErrorHandler implements ServerConnectorErrorHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketServerConnectorErrorHandler.class);
+
+    @Override
+    public void handleError(Exception e, CarbonMessage carbonMessage, CarbonCallback carbonCallback) throws Exception {
+        logger.debug("Error Occurred : " + e.getMessage());
+    }
+
+    @Override
+    public String getProtocol() {
+        return Constants.WEBSOCKET_PROTOCOL;
+    }
+}

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/WebSocketServerConnectorErrorHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/WebSocketServerConnectorErrorHandler.java
@@ -43,7 +43,7 @@ public class WebSocketServerConnectorErrorHandler implements ServerConnectorErro
     @Override
     public void handleError(Exception e, CarbonMessage carbonMessage, CarbonCallback carbonCallback) throws Exception {
         //This debug log will be used in error debugging in the server connector.
-        logger.debug("Error occurred : " + e.getMessage());
+        logger.debug("Error occurred : " + e.getMessage(), e);
     }
 
     @Override

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/WebSocketServerConnectorErrorHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/WebSocketServerConnectorErrorHandler.java
@@ -42,7 +42,8 @@ public class WebSocketServerConnectorErrorHandler implements ServerConnectorErro
 
     @Override
     public void handleError(Exception e, CarbonMessage carbonMessage, CarbonCallback carbonCallback) throws Exception {
-        logger.debug("Error Occurred : " + e.getMessage());
+        //This debug log will be used in error debugging in the server connector.
+        logger.debug("Error occurred : " + e.getMessage());
     }
 
     @Override

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/WebSocketSourceHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/WebSocketSourceHandler.java
@@ -111,7 +111,6 @@ public class WebSocketSourceHandler extends SourceHandler {
             ByteBuf byteBuf = pongWebSocketFrame.content();
             ByteBuffer byteBuffer = byteBuf.nioBuffer();
             cMsg = new ControlCarbonMessage(byteBuffer, finalFragment);
-            byteBuf.release();
 
         }
         setupCarbonMessage(ctx);

--- a/http/org.wso2.carbon.transport.http.netty/src/main/resources/META-INF/services/org.wso2.carbon.messaging.ServerConnectorErrorHandler
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/resources/META-INF/services/org.wso2.carbon.messaging.ServerConnectorErrorHandler
@@ -1,1 +1,2 @@
 org.wso2.carbon.transport.http.netty.listener.HTTPServerConnectorErrorHandler
+org.wso2.carbon.transport.http.netty.listener.WebSocketServerConnectorErrorHandler


### PR DESCRIPTION
There is a need for a WebSocket server connector error handler for transport since all the errors occur in WebSocket protocol will be handled through this error handler.

solves #180