### PR TITLE
Fix context not set issue when adding http source handler through http2

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
@@ -86,18 +86,19 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
     }
 
     @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        super.handlerAdded(ctx);
+        this.ctx = ctx;
+        this.targetChannelPool = connectionManager.getTargetChannelPool();
+    }
+
+    @Override
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
         // Start the server connection Timer
-
         if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
-
             HTTPTransportContextHolder.getInstance().getHandlerExecutor()
                     .executeAtSourceConnectionInitiation(Integer.toString(ctx.hashCode()));
         }
-
-        this.ctx = ctx;
-        this.targetChannelPool = connectionManager.getTargetChannelPool();
-
     }
 
     @SuppressWarnings("unchecked")

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
@@ -99,6 +99,10 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             HTTPTransportContextHolder.getInstance().getHandlerExecutor()
                     .executeAtSourceConnectionInitiation(Integer.toString(ctx.hashCode()));
         }
+        this.ctx = ctx;
+        if (this.targetChannelPool == null) {
+            this.targetChannelPool = connectionManager.getTargetChannelPool();
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTPProtocolNegotiationHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTPProtocolNegotiationHandler.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.carbon.transport.http.netty.config.RequestSizeValidationConfiguration;
+import org.wso2.carbon.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.carbon.transport.http.netty.listener.CustomHttpObjectAggregator;
 import org.wso2.carbon.transport.http.netty.listener.CustomHttpRequestDecoder;
 import org.wso2.carbon.transport.http.netty.listener.SourceHandler;
@@ -93,6 +94,15 @@ public class HTTPProtocolNegotiationHandler extends ApplicationProtocolNegotiati
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (ctx != null && ctx.channel().isActive()) {
             ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    @Override
+    public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+        // Start the server connection Timer
+        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+            HTTPTransportContextHolder.getInstance().getHandlerExecutor()
+                    .executeAtSourceConnectionInitiation(Integer.toString(ctx.hashCode()));
         }
     }
 }


### PR DESCRIPTION
We initialize source handler  variables in channel active event method . But in http/2 ssl scenario channel active event happen before source handler adding to pipeline. Because of that context variable not set.

This should be done in handler add event method since it calls every time adding new source handler.