### PR TITLE
HTTP/2 Bug fixes

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2SourceHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2SourceHandler.java
@@ -63,7 +63,6 @@ public final class HTTP2SourceHandler extends Http2ConnectionHandler implements 
      * http2 tcp connections
      */
     private Map<Integer, HTTPCarbonMessage> streamIdRequestMap = PlatformDependent.newConcurrentHashMap();
-    private ConnectionManager connectionManager;
     private ListenerConfiguration listenerConfiguration;
     private ChannelHandlerContext ctx;
 
@@ -72,7 +71,6 @@ public final class HTTP2SourceHandler extends Http2ConnectionHandler implements 
                                listenerConfiguration) {
         super(decoder, encoder, initialSettings);
         this.listenerConfiguration = listenerConfiguration;
-        this.connectionManager = connectionManager;
     }
 
     @Override
@@ -152,7 +150,6 @@ public final class HTTP2SourceHandler extends Http2ConnectionHandler implements 
             HTTPTransportContextHolder.getInstance().getHandlerExecutor()
                     .executeAtSourceConnectionTermination(Integer.toString(ctx.hashCode()));
         }
-        connectionManager.notifyChannelInactive();
     }
 
 


### PR DESCRIPTION
When doing load test some requests were failed due to thread blocking during channel flush. Currently we are using encoder directly to write to channel but it has encoder write method does not check whether the channel is in event loop. Using writer object this can be fix.

Connection Initiation handler executors does get fired during upgrade http/2 and http requests. Fixed with this pull request