### PR TITLE
Implement a new connection pooling mechanism

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Constants.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Constants.java
@@ -96,6 +96,8 @@ public final class Constants {
 
     public static final String MAX_IDLE_CONNECTIONS_PER_POOL = "cleint.max.idle.connections.per.pool";
 
+    public static final String MAX_WAIT_FOR_CLIENT_CONNECTION_POOL = "max.wait.for.client.connection.pool";
+
     public static final String MIN_EVICTION_IDLE_TIME = "client.min.eviction.idle.time";
 
     public static final String ENABLE_GLOBAL_CONNECTION_POOLING = "enable.global.client.connection.pooling";

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/config/ListenerConfiguration.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/config/ListenerConfiguration.java
@@ -77,6 +77,9 @@ public class ListenerConfiguration {
     @XmlAttribute
     private String certPass;
 
+    @XmlAttribute
+    private int socketIdleTimeout;
+
     @XmlElementWrapper(name = "parameters")
     @XmlElement(name = "parameter")
     private List<Parameter> parameters = getDefaultParameters();
@@ -183,5 +186,16 @@ public class ListenerConfiguration {
         List<Parameter> defaultParams = new ArrayList<>();
         return defaultParams;
 
+    }
+
+    public int getSocketIdleTimeout(int defaultVal) {
+        if (socketIdleTimeout == 0) {
+            return defaultVal;
+        }
+        return socketIdleTimeout;
+    }
+
+    public void setSocketIdleTimeout(int socketIdleTimeout) {
+        this.socketIdleTimeout = socketIdleTimeout;
     }
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/config/SenderConfiguration.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/config/SenderConfiguration.java
@@ -65,6 +65,9 @@ public class SenderConfiguration {
     @XmlAttribute
     private String certPass;
 
+    @XmlAttribute
+    private int socketIdleTimeout;
+
     @XmlElementWrapper(name = "parameters")
     @XmlElement(name = "parameter")
     private List<Parameter> parameters;
@@ -133,5 +136,14 @@ public class SenderConfiguration {
                 parameters);
     }
 
+    public int getSocketIdleTimeout(int defaultValue) {
+        if (socketIdleTimeout == 0) {
+            return defaultValue;
+        }
+        return socketIdleTimeout;
+    }
 
+    public void setSocketIdleTimeout(int socketIdleTimeout) {
+        this.socketIdleTimeout = socketIdleTimeout;
+    }
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
@@ -28,6 +28,7 @@ import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AsciiString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -180,6 +181,10 @@ public class HTTPServerChannelInitializer extends ChannelInitializer<SocketChann
         p.addLast("compressor", new HttpContentCompressor());
         p.addLast("chunkWriter", new ChunkedWriteHandler());
         try {
+            int socketIdleTimeout = listenerConfiguration.getSocketIdleTimeout(60);
+            // TODO: Let's improve this later for read and write timeouts
+            p.addLast("idleStateHandler",
+                    new IdleStateHandler(socketIdleTimeout, socketIdleTimeout, socketIdleTimeout));
             p.addLast("handler", new SourceHandler(connectionManager, listenerConfiguration));
         } catch (Exception e) {
             log.error("Cannot Create SourceHandler ", e);

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
@@ -196,4 +196,7 @@ public class HTTPServerChannelInitializer extends ChannelInitializer<SocketChann
         return true;
     }
 
+    public ConnectionManager getConnectionManager() {
+        return connectionManager;
+    }
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/ServerConnectorController.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/ServerConnectorController.java
@@ -143,6 +143,7 @@ public class ServerConnectorController {
     }
 
     public void stop() {
+        handler.getConnectionManager().getTargetChannelPool().clear();
         shutdownEventLoops();
     }
 

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
@@ -267,7 +267,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         if (connectionManager.getPoolConfiguration().getNumberOfPools() == 0) {
             targetChannelPool.forEach((k, genericObjectPool) -> {
                 try {
-                    genericObjectPool.close();
+                    targetChannelPool.remove(k).close();
                 } catch (Exception e) {
                     log.error("Couldn't close target channel socket connections", e);
                 }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
@@ -264,13 +264,6 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             HTTPTransportContextHolder.getInstance().getHandlerExecutor()
                     .executeAtSourceConnectionTermination(Integer.toString(ctx.hashCode()));
         }
-        targetChannelPool.forEach((k, genericObjectPool) -> {
-            try {
-                genericObjectPool.close();
-            } catch (Exception e) {
-                log.error("Couldn't close target channel socket connections", e);
-            }
-        });
         targetChannelPerHostPool.forEach((k, targetChannel) -> targetChannel.getChannel().close());
         connectionManager.notifyChannelInactive();
     }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/ClientRequestWorker.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/ClientRequestWorker.java
@@ -135,6 +135,10 @@ public class ClientRequestWorker implements Runnable {
             if (obj != null) {
                 TargetChannel targetChannel = (TargetChannel) obj;
                 targetChannel.setTargetHandler(targetChannel.getHTTPClientInitializer().getTargetHandler());
+                targetChannel.setHttpRoute(httpRoute);
+                if (sourceHandler != null) {
+                    targetChannel.setCorrelatedSource(sourceHandler);
+                }
                 return targetChannel;
             }
         } catch (Exception e) {

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/ClientRequestWorker.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/ClientRequestWorker.java
@@ -16,8 +16,6 @@
 
 package org.wso2.carbon.transport.http.netty.sender;
 
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.http.HttpRequest;
 import org.apache.commons.pool.impl.GenericObjectPool;
@@ -72,34 +70,34 @@ public class ClientRequestWorker implements Runnable {
 
     @Override
     public void run() {
-        Channel channel = null;
-        TargetChannel targetChannel = null;
+        // TODO: Talk to others and remove it!!
+//        if (poolManagementPolicy == ConnectionManager.PoolManagementPolicy.
+//                PER_SERVER_CHANNEL_ENDPOINT_CONNECTION_CACHING) {
+//            targetChannel = new TargetChannel();
+//            ChannelFuture future = ChannelUtils
+//                    .getNewChannelFuture(targetChannel, eventLoopGroup, aClass, httpRoute, senderConfig);
+//
+//            try {
+//                channel = ChannelUtils.openChannel(future, httpRoute);
+//            } catch (Exception failedCause) {
+//                String msg = "Error when creating channel for route " + httpRoute;
+//                log.error(msg, failedCause);
+//                MessagingException messagingException = new MessagingException(msg, failedCause, 101503);
+//                carbonMessage.setMessagingException(messagingException);
+//                carbonCallback.done(carbonMessage);
+//                return;
+//            } finally {
+//                if (channel != null) {
+//                    targetChannel.setChannel(channel);
+//                    targetChannel.setTargetHandler(targetChannel.getHTTPClientInitializer().getTargetHandler());
+//                }
+//            }
+//        } else {
+//            targetChannel = processThroughConnectionPool();
+//
+//        }
 
-        if (poolManagementPolicy == ConnectionManager.PoolManagementPolicy.
-                PER_SERVER_CHANNEL_ENDPOINT_CONNECTION_CACHING) {
-            targetChannel = new TargetChannel();
-            ChannelFuture future = ChannelUtils
-                    .getNewChannelFuture(targetChannel, eventLoopGroup, aClass, httpRoute, senderConfig);
-
-            try {
-                channel = ChannelUtils.openChannel(future, httpRoute);
-            } catch (Exception failedCause) {
-                String msg = "Error when creating channel for route " + httpRoute;
-                log.error(msg, failedCause);
-                MessagingException messagingException = new MessagingException(msg, failedCause, 101503);
-                carbonMessage.setMessagingException(messagingException);
-                carbonCallback.done(carbonMessage);
-                return;
-            } finally {
-                if (channel != null) {
-                    targetChannel.setChannel(channel);
-                    targetChannel.setTargetHandler(targetChannel.getHTTPClientInitializer().getTargetHandler());
-                }
-            }
-        } else {
-            targetChannel = processThroughConnectionPool();
-
-        }
+        TargetChannel targetChannel = processThroughConnectionPool();
         if (targetChannel != null) {
             targetChannel.setHttpRoute(httpRoute);
             if (targetChannel.getTargetHandler() != null) {

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientConnector.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientConnector.java
@@ -135,19 +135,6 @@ public class HTTPClientConnector implements ClientConnector {
         try {
             connectionManager.
                     executeTargetChannel(route, srcHandler, senderConfiguration, httpRequest, msg, callback);
-            // TODO: Remove this in the next release!!
-//              TargetChannel targetChannel = connectionManager.
-//                     executeTargetChannel(route, srcHandler, senderConfiguration, httpRequest, msg, callback);
-//            if (targetChannel != null) {
-//                TargetHandler targetHandler = targetChannel.getTargetHandler();
-//                targetHandler.setCallback(callback);
-//                targetHandler.setIncomingMsg(msg);
-//                targetHandler.setConnectionManager(connectionManager);
-//                targetHandler.setTargetChannel(targetChannel);
-//                if (ChannelUtils.writeContent(targetChannel.getChannel(), httpRequest, msg)) {
-//                    targetChannel.setRequestWritten(true); // If request written
-//                }
-//            }
         } catch (Exception failedCause) {
             throw new ClientConnectorException(failedCause.getMessage(), failedCause);
         }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientConnector.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientConnector.java
@@ -35,8 +35,6 @@ import org.wso2.carbon.transport.http.netty.config.TransportsConfiguration;
 import org.wso2.carbon.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.carbon.transport.http.netty.listener.SourceHandler;
 import org.wso2.carbon.transport.http.netty.sender.channel.BootstrapConfiguration;
-import org.wso2.carbon.transport.http.netty.sender.channel.ChannelUtils;
-import org.wso2.carbon.transport.http.netty.sender.channel.TargetChannel;
 import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManager;
 
 import java.util.HashMap;
@@ -135,18 +133,21 @@ public class HTTPClientConnector implements ClientConnector {
         }
 
         try {
-            TargetChannel targetChannel = connectionManager.
-                    getTargetChannel(route, srcHandler, senderConfiguration, httpRequest, msg, callback);
-            if (targetChannel != null) {
-                TargetHandler targetHandler = targetChannel.getTargetHandler();
-                targetHandler.setCallback(callback);
-                targetHandler.setIncomingMsg(msg);
-                targetHandler.setConnectionManager(connectionManager);
-                targetHandler.setTargetChannel(targetChannel);
-                if (ChannelUtils.writeContent(targetChannel.getChannel(), httpRequest, msg)) {
-                    targetChannel.setRequestWritten(true); // If request written
-                }
-            }
+            connectionManager.
+                    executeTargetChannel(route, srcHandler, senderConfiguration, httpRequest, msg, callback);
+            // TODO: Remove this in the next release!!
+//              TargetChannel targetChannel = connectionManager.
+//                     executeTargetChannel(route, srcHandler, senderConfiguration, httpRequest, msg, callback);
+//            if (targetChannel != null) {
+//                TargetHandler targetHandler = targetChannel.getTargetHandler();
+//                targetHandler.setCallback(callback);
+//                targetHandler.setIncomingMsg(msg);
+//                targetHandler.setConnectionManager(connectionManager);
+//                targetHandler.setTargetChannel(targetChannel);
+//                if (ChannelUtils.writeContent(targetChannel.getChannel(), httpRequest, msg)) {
+//                    targetChannel.setRequestWritten(true); // If request written
+//                }
+//            }
         } catch (Exception failedCause) {
             throw new ClientConnectorException(failedCause.getMessage(), failedCause);
         }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientInitializer.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientInitializer.java
@@ -62,9 +62,7 @@ public class HTTPClientInitializer extends ChannelInitializer<SocketChannel> {
         ch.pipeline().addLast("chunkWriter", new ChunkedWriteHandler());
 
         handler = new TargetHandler();
-        // -1 means timer tasks are disabled, please see TargetHandler class comment
         ch.pipeline().addLast(HANDLER, handler);
-
     }
 
     public TargetHandler getTargetHandler() {

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientInitializer.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientInitializer.java
@@ -61,7 +61,7 @@ public class HTTPClientInitializer extends ChannelInitializer<SocketChannel> {
         ch.pipeline().addLast("encoder", new HttpRequestEncoder());
         ch.pipeline().addLast("chunkWriter", new ChunkedWriteHandler());
 
-        handler = new TargetHandler(-1);
+        handler = new TargetHandler();
         // -1 means timer tasks are disabled, please see TargetHandler class comment
         ch.pipeline().addLast(HANDLER, handler);
 

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPSender.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPSender.java
@@ -102,25 +102,9 @@ public class HTTPSender implements TransportSender {
                     + "listener side please copy property SRC_HANDLER from incoming message");
         }
 
-
-//        Channel outboundChannel = null;
         try {
             connectionManager
                     .executeTargetChannel(route, srcHandler, defaultSenderConfiguration, httpRequest, msg, callback);
-            // TODO: Remove this in the next release!
-//            TargetChannel targetChannel = connectionManager
-//                    .executeTargetChannel(route, srcHandler, defaultSenderConfiguration, httpRequest, msg, callback);
-//            if (targetChannel != null) {
-//                outboundChannel = targetChannel.getChannel();
-//                targetChannel.getTargetHandler().setCallback(callback);
-//                targetChannel.getTargetHandler().setIncomingMsg(msg);
-//                targetChannel.getTargetHandler().setTargetChannel(targetChannel);
-//                targetChannel.getTargetHandler().setConnectionManager(connectionManager);
-//                boolean written = ChannelUtils.writeContent(outboundChannel, httpRequest, msg);
-//                if (written) {
-//                    targetChannel.setRequestWritten(true);
-//                }
-//            }
         } catch (Exception failedCause) {
             throw new MessageProcessorException(failedCause.getMessage(), failedCause);
         }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPSender.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPSender.java
@@ -15,7 +15,6 @@
 
 package org.wso2.carbon.transport.http.netty.sender;
 
-import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,8 +30,6 @@ import org.wso2.carbon.transport.http.netty.config.SenderConfiguration;
 import org.wso2.carbon.transport.http.netty.config.TransportProperty;
 import org.wso2.carbon.transport.http.netty.listener.SourceHandler;
 import org.wso2.carbon.transport.http.netty.sender.channel.BootstrapConfiguration;
-import org.wso2.carbon.transport.http.netty.sender.channel.ChannelUtils;
-import org.wso2.carbon.transport.http.netty.sender.channel.TargetChannel;
 import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManager;
 
 import java.util.HashMap;
@@ -105,21 +102,25 @@ public class HTTPSender implements TransportSender {
                     + "listener side please copy property SRC_HANDLER from incoming message");
         }
 
-        Channel outboundChannel = null;
+
+//        Channel outboundChannel = null;
         try {
-            TargetChannel targetChannel = connectionManager
-                    .getTargetChannel(route, srcHandler, defaultSenderConfiguration, httpRequest, msg, callback);
-            if (targetChannel != null) {
-                outboundChannel = targetChannel.getChannel();
-                targetChannel.getTargetHandler().setCallback(callback);
-                targetChannel.getTargetHandler().setIncomingMsg(msg);
-                targetChannel.getTargetHandler().setTargetChannel(targetChannel);
-                targetChannel.getTargetHandler().setConnectionManager(connectionManager);
-                boolean written = ChannelUtils.writeContent(outboundChannel, httpRequest, msg);
-                if (written) {
-                    targetChannel.setRequestWritten(true);
-                }
-            }
+            connectionManager
+                    .executeTargetChannel(route, srcHandler, defaultSenderConfiguration, httpRequest, msg, callback);
+            // TODO: Remove this in the next release!
+//            TargetChannel targetChannel = connectionManager
+//                    .executeTargetChannel(route, srcHandler, defaultSenderConfiguration, httpRequest, msg, callback);
+//            if (targetChannel != null) {
+//                outboundChannel = targetChannel.getChannel();
+//                targetChannel.getTargetHandler().setCallback(callback);
+//                targetChannel.getTargetHandler().setIncomingMsg(msg);
+//                targetChannel.getTargetHandler().setTargetChannel(targetChannel);
+//                targetChannel.getTargetHandler().setConnectionManager(connectionManager);
+//                boolean written = ChannelUtils.writeContent(outboundChannel, httpRequest, msg);
+//                if (written) {
+//                    targetChannel.setRequestWritten(true);
+//                }
+//            }
         } catch (Exception failedCause) {
             throw new MessageProcessorException(failedCause.getMessage(), failedCause);
         }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
@@ -115,6 +115,8 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         ctx.close();
+        connectionManager.invalidateTargetChannel(targetChannel);
+
         if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
             HTTPTransportContextHolder.getInstance().getHandlerExecutor()
                     .executeAtTargetConnectionTermination(Integer.toString(ctx.hashCode()));

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
@@ -17,11 +17,11 @@ package org.wso2.carbon.transport.http.netty.sender;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.handler.timeout.ReadTimeoutHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonCallback;
@@ -48,7 +48,7 @@ import java.util.Map;
  * causes timeout issues when TargetHandler is re-used from the ConnectionManager.
  *
  */
-public class TargetHandler extends ReadTimeoutHandler {
+public class TargetHandler extends ChannelInboundHandlerAdapter {
     protected static final Logger LOG = LoggerFactory.getLogger(TargetHandler.class);
 
     protected CarbonCallback callback;
@@ -57,8 +57,7 @@ public class TargetHandler extends ReadTimeoutHandler {
     protected TargetChannel targetChannel;
     protected CarbonMessage incomingMsg;
 
-    public TargetHandler(int timeoutSeconds) {
-        super(timeoutSeconds);
+    public TargetHandler() {
     }
 
     @Override
@@ -139,7 +138,7 @@ public class TargetHandler extends ReadTimeoutHandler {
         this.targetChannel = targetChannel;
     }
 
-    @Override
+    // TODO: This cannot be done as long as we use apache pooling.
     protected void readTimedOut(ChannelHandlerContext ctx) {
 
         ctx.channel().close();

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
@@ -171,10 +171,6 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
             HTTPTransportContextHolder.getInstance().getHandlerExecutor().executeAtTargetResponseReceiving(cMsg);
         }
 
-        // TODO: Make them available through util messages.
-//        cMsg.setProperty(Constants.PORT, ((InetSocketAddress) ctx.channel().remoteAddress()).getPort());
-//        cMsg.setProperty(Constants.HOST, ((InetSocketAddress) ctx.channel().remoteAddress()).getHostName());
-
         cMsg.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
                 org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
         cMsg.setProperty(org.wso2.carbon.messaging.Constants.CALL_BACK, callback);

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
@@ -22,7 +22,6 @@ import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.handler.timeout.IdleStateEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonCallback;
@@ -214,13 +213,6 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (ctx != null && ctx.channel().isActive()) {
             ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
-        }
-    }
-
-    @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        if (evt instanceof IdleStateEvent) {
-            ctx.close();
         }
     }
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.timeout.IdleStateEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonCallback;
@@ -217,6 +218,13 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (ctx != null && ctx.channel().isActive()) {
             ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof IdleStateEvent) {
+            ctx.close();
         }
     }
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/ChannelUtils.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/ChannelUtils.java
@@ -39,8 +39,6 @@ import org.wso2.carbon.transport.http.netty.sender.HTTPClientInitializer;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Utility class for Channel handling.
@@ -100,21 +98,23 @@ public class ChannelUtils {
                     bootstrapConfiguration.getConnectTimeOut());
         }
 
+        // TODO: Remove this in the next release!!!
         // here we need to wait it in other thread
-        final CountDownLatch channelLatch = new CountDownLatch(1);
-        channelFuture.addListener(cf -> channelLatch.countDown());
+//        final CountDownLatch channelLatch = new CountDownLatch(1);
+//        channelFuture.addListener(cf -> channelLatch.countDown());
+//
+//        try {
+//            boolean wait = channelLatch.await(bootstrapConfiguration.getConnectTimeOut(), TimeUnit.MILLISECONDS);
+//            if (wait) {
+//                log.debug("Waited for connection creation in Sender");
+//            }
+//        } catch (InterruptedException ex) {
+//            throw new Exception("Interrupted while waiting for " + "connection to " + httpRoute.toString());
+//        }
 
-        try {
-            boolean wait = channelLatch.await(bootstrapConfiguration.getConnectTimeOut(), TimeUnit.MILLISECONDS);
-            if (wait) {
-                log.debug("Waited for connection creation in Sender");
-            }
-        } catch (InterruptedException ex) {
-            throw new Exception("Interrupted while waiting for " + "connection to " + httpRoute.toString());
-        }
-
+        // this wait is okay as we have a timeout in connect method
+        channelFuture.awaitUninterruptibly();
         Channel channel = null;
-
         if (channelFuture.isDone() && channelFuture.isSuccess()) {
             channel = channelFuture.channel();
             if (log.isDebugEnabled()) {

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/ChannelUtils.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/ChannelUtils.java
@@ -98,20 +98,6 @@ public class ChannelUtils {
                     bootstrapConfiguration.getConnectTimeOut());
         }
 
-        // TODO: Remove this in the next release!!!
-        // here we need to wait it in other thread
-//        final CountDownLatch channelLatch = new CountDownLatch(1);
-//        channelFuture.addListener(cf -> channelLatch.countDown());
-//
-//        try {
-//            boolean wait = channelLatch.await(bootstrapConfiguration.getConnectTimeOut(), TimeUnit.MILLISECONDS);
-//            if (wait) {
-//                log.debug("Waited for connection creation in Sender");
-//            }
-//        } catch (InterruptedException ex) {
-//            throw new Exception("Interrupted while waiting for " + "connection to " + httpRoute.toString());
-//        }
-
         // this wait is okay as we have a timeout in connect method
         channelFuture.awaitUninterruptibly();
         Channel channel = null;

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -230,7 +230,11 @@ public class ConnectionManager {
                     }
                 }
             } catch (Exception e) {
-                log.error("Failed to send the request through the default pooling", e);
+                String msg = "Failed to send the request through the default pooling";
+                log.error(msg, e);
+                MessagingException messagingException = new MessagingException(msg, e, 101500);
+                carbonMessage.setMessagingException(messagingException);
+                carbonCallback.done(carbonMessage);
             }
             return;
         }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -291,7 +291,8 @@ public class ConnectionManager {
             Map<String, GenericObjectPool> objectPoolMap = targetChannel.getCorrelatedSource().getTargetChannelPool();
             releaseChannelToPool(targetChannel, objectPoolMap.get(targetChannel.getHttpRoute().toString()));
         } else if (poolManagementPolicy == PoolManagementPolicy.DEFAULT_POOLING) {
-            Map<String, TargetChannel> objectPoolMap = targetChannel.getCorrelatedSource().getTargetChannelPerHostPool();
+            Map<String, TargetChannel> objectPoolMap = targetChannel.getCorrelatedSource()
+                    .getTargetChannelPerHostPool();
             objectPoolMap.put(targetChannel.getHttpRoute().toString(), targetChannel);
         }
     }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -39,8 +39,6 @@ import org.wso2.carbon.transport.http.netty.sender.TargetHandler;
 import org.wso2.carbon.transport.http.netty.sender.channel.ChannelUtils;
 import org.wso2.carbon.transport.http.netty.sender.channel.TargetChannel;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -57,7 +55,7 @@ public class ConnectionManager {
     private static volatile ConnectionManager connectionManager;
     private PoolConfiguration poolConfiguration;
     private PoolManagementPolicy poolManagementPolicy;
-    private final List<Map<String, GenericObjectPool>> poolList;
+    private final Map<String, GenericObjectPool> poolList;
     private AtomicInteger index = new AtomicInteger(1);
     private int poolCount;
 
@@ -79,11 +77,7 @@ public class ConnectionManager {
 //            this.poolManagementPolicy = PoolManagementPolicy.PER_SERVER_CHANNEL_ENDPOINT_CONNECTION_CACHING;
 //        }
 
-        poolList = new ArrayList<>();
-        for (int i = 0; i < poolCount; i++) {
-            Map<String, GenericObjectPool> map = new ConcurrentHashMap<>();
-            poolList.add(map);
-        }
+        poolList = new ConcurrentHashMap<>();
 
         clientEventGroup = new NioEventLoopGroup(
                 Util.getIntProperty(transportProperties, Constants.CLIENT_BOOTSTRAP_WORKER_GROUP_SIZE, 4));
@@ -338,11 +332,7 @@ public class ConnectionManager {
      * @return Map contains pools for each route
      */
     public Map<String, GenericObjectPool> getTargetChannelPool() {
-        if (poolManagementPolicy == PoolManagementPolicy.GLOBAL_ENDPOINT_CONNECTION_CACHING) {
-            int ind = index.getAndIncrement() % poolCount;
-            return poolList.get(ind);
-        }
-        return null;
+        return this.poolList;
     }
 
     public void notifyChannelInactive() {

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -229,6 +229,15 @@ public class ConnectionManager {
         }
     }
 
+    public void invalidateTargetChannel(TargetChannel targetChannel) throws Exception {
+        Map<String, GenericObjectPool> objectPoolMap = targetChannel.getCorrelatedSource().getTargetChannelPool();
+        try {
+            objectPoolMap.get(targetChannel.getHttpRoute().toString()).invalidateObject(targetChannel);
+        } catch (Exception e) {
+            throw new Exception("Cannot invalidate channel from pool", e);
+        }
+    }
+
     /**
      * Provide specific target channel map.
      *

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -205,8 +205,8 @@ public class ConnectionManager {
             }
         } else if (poolManagementPolicy == PoolManagementPolicy.LOCKLESS_DEFAULT_POOLING) {
             // this is the lock less impl of LOCK_DEFAULT_POOLING. 90% of the
-            // time this should work unless user decide to weird integrations.
-            // just kept it here in case we need extreme level of per numbers.
+            // time this should work unless user decide to do weird integrations.
+            // just kept it here in case we need extreme level of perf numbers.
             try {
                 Map<String, TargetChannel> connPool = sourceHandler.getTargetChannelPerHostPool();
                 TargetChannel targetChannel = connPool.remove(httpRoute.toString());

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -100,6 +100,19 @@ public class ConnectionManager {
 
     }
 
+    private GenericObjectPool createPoolForRoutePerSrcHndlr(GenericObjectPool genericObjectPool) {
+        GenericObjectPool.Config config = new GenericObjectPool.Config();
+        config.maxActive = poolConfiguration.getMaxActivePerPool();
+        config.maxIdle = poolConfiguration.getMaxIdlePerPool();
+        config.minIdle = poolConfiguration.getMinIdlePerPool();
+        config.testOnBorrow = poolConfiguration.isTestOnBorrow();
+        config.testWhileIdle = poolConfiguration.isTestWhileIdle();
+        config.timeBetweenEvictionRunsMillis = poolConfiguration.getTimeBetweenEvictionRuns();
+        config.minEvictableIdleTimeMillis = poolConfiguration.getMinEvictableIdleTime();
+        config.whenExhaustedAction = poolConfiguration.getExhaustedAction();
+        return new GenericObjectPool(new PoolableTargetChannelFactoryPerSrcHndlr(genericObjectPool), config);
+    }
+
     public static ConnectionManager getInstance(Map<String, Object> transportProperties) {
         if (connectionManager == null) {
             synchronized (ConnectionManager.class) {

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -74,6 +74,7 @@ public class ConnectionManager {
         config.timeBetweenEvictionRunsMillis = poolConfiguration.getTimeBetweenEvictionRuns();
         config.minEvictableIdleTimeMillis = poolConfiguration.getMinEvictableIdleTime();
         config.whenExhaustedAction = poolConfiguration.getExhaustedAction();
+        config.maxWait = poolConfiguration.getMaxWait();
         return new GenericObjectPool(
                 new PoolableTargetChannelFactory(httpRoute, eventLoopGroup, eventLoopClass, senderConfiguration),
                 config);

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolConfiguration.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolConfiguration.java
@@ -46,7 +46,7 @@ public class PoolConfiguration {
 
     private long minEvictableIdleTime = 5 * 60 * 1000L;
 
-    private byte exhaustedAction = GenericObjectPool.WHEN_EXHAUSTED_GROW;
+    private byte exhaustedAction = GenericObjectPool.WHEN_EXHAUSTED_BLOCK;
 
     private int numberOfPools = 0;
 
@@ -67,8 +67,8 @@ public class PoolConfiguration {
         maxIdlePerPool = Util.getIntProperty(
                 transportProperties, Constants.MAX_IDLE_CONNECTIONS_PER_POOL, 100);
 
-        minEvictableIdleTime = Util.getLongProperty(
-                transportProperties, Constants.MIN_EVICTION_IDLE_TIME, 5 * 60 * 1000L);
+        minEvictableIdleTime = Util.getIntProperty(
+                transportProperties, Constants.MIN_EVICTION_IDLE_TIME, 5 * 60 * 1000);
 
         executorServiceThreads = Util.getIntProperty(
                 transportProperties, Constants.NO_THREADS_IN_EXECUTOR_SERVICE, 20);

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolConfiguration.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolConfiguration.java
@@ -54,6 +54,8 @@ public class PoolConfiguration {
 
     private int eventGroupExecutorThreads = 15;
 
+    private long setMaxWait = 60000L;
+
     private PoolConfiguration(Map<String, Object> transportProperties) {
 
         numberOfPools = Util.getIntProperty(transportProperties, Constants.NUMBER_OF_POOLS, 0);
@@ -75,6 +77,9 @@ public class PoolConfiguration {
 
         eventGroupExecutorThreads = Util.getIntProperty(
                 transportProperties, Constants.EVENT_GROUP_EXECUTOR_THREAD_SIZE, 15);
+
+        eventGroupExecutorThreads = Util.getIntProperty(
+                transportProperties, Constants.MAX_WAIT_FOR_CLIENT_CONNECTION_POOL, 60000);
 
         logger.debug(Constants.NUMBER_OF_POOLS + ": " + numberOfPools);
         logger.debug(Constants.MAX_ACTIVE_CONNECTIONS_PER_POOL + ":" + maxActivePerPool);
@@ -138,5 +143,9 @@ public class PoolConfiguration {
 
     public int getEventGroupExecutorThreads() {
         return eventGroupExecutorThreads;
+    }
+
+    public long getMaxWait() {
+        return setMaxWait;
     }
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
@@ -29,20 +29,15 @@ public class PoolableTargetChannelFactoryPerSrcHndlr implements PoolableObjectFa
 
     private static final Logger log = LoggerFactory.getLogger(PoolableTargetChannelFactoryPerSrcHndlr.class);
 
-    private GenericObjectPool genericObjectPool;
+    private final GenericObjectPool genericObjectPool;
 
     public PoolableTargetChannelFactoryPerSrcHndlr(GenericObjectPool genericObjectPool) {
         this.genericObjectPool = genericObjectPool;
     }
 
-
     @Override
     public Object makeObject() throws Exception {
         TargetChannel targetChannel = (TargetChannel) this.genericObjectPool.borrowObject();
-        while (!targetChannel.getChannel().isActive() || !targetChannel.getChannel().isOpen()) {
-            this.genericObjectPool.invalidateObject(targetChannel);
-            targetChannel = (TargetChannel) this.genericObjectPool.borrowObject();
-        }
         log.debug("Created channel: {}", targetChannel);
         return targetChannel;
     }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.wso2.carbon.transport.http.netty.sender.channel.pool;
+
+
+import org.apache.commons.pool.PoolableObjectFactory;
+import org.apache.commons.pool.impl.GenericObjectPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.transport.http.netty.sender.channel.TargetChannel;
+
+/**
+ * A class which creates a TargetChannel pool for each route.
+ */
+public class PoolableTargetChannelFactoryPerSrcHndlr implements PoolableObjectFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(PoolableTargetChannelFactoryPerSrcHndlr.class);
+
+    private GenericObjectPool genericObjectPool;
+
+    public PoolableTargetChannelFactoryPerSrcHndlr(GenericObjectPool genericObjectPool) {
+        this.genericObjectPool = genericObjectPool;
+    }
+
+
+    @Override
+    public Object makeObject() throws Exception {
+        TargetChannel targetChannel = (TargetChannel) this.genericObjectPool.borrowObject();
+        while (!targetChannel.getChannel().isActive() || !targetChannel.getChannel().isOpen()) {
+            this.genericObjectPool.invalidateObject(targetChannel);
+            targetChannel = (TargetChannel) this.genericObjectPool.borrowObject();
+        }
+        log.debug("Created channel: {}", targetChannel);
+        return targetChannel;
+    }
+
+    @Override
+    public void destroyObject(Object o) throws Exception {
+        if (((TargetChannel) o).getChannel().isOpen()) {
+            this.genericObjectPool.returnObject(o);
+        }
+        log.debug("Destroying channel: {}", o);
+    }
+
+    @Override
+    public boolean validateObject(Object o) {
+        boolean answer = ((TargetChannel) o).getChannel().isActive();
+        log.debug("Validating channel: {} -> {}", o, answer);
+        return answer;
+    }
+
+    @Override
+    public void activateObject(Object o) throws Exception {
+
+    }
+
+    @Override
+    public void passivateObject(Object o) throws Exception {
+
+    }
+
+
+}

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
@@ -44,8 +44,10 @@ public class PoolableTargetChannelFactoryPerSrcHndlr implements PoolableObjectFa
 
     @Override
     public void destroyObject(Object o) throws Exception {
-        if (((TargetChannel) o).getChannel().isOpen()) {
+        if (((TargetChannel) o).getChannel().isActive()) {
             this.genericObjectPool.returnObject(o);
+        } else {
+            this.genericObjectPool.invalidateObject(o);
         }
         log.debug("Destroying channel: {}", o);
     }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
@@ -60,14 +60,8 @@ public class PoolableTargetChannelFactoryPerSrcHndlr implements PoolableObjectFa
     }
 
     @Override
-    public void activateObject(Object o) throws Exception {
-
-    }
+    public void activateObject(Object o) throws Exception {}
 
     @Override
-    public void passivateObject(Object o) throws Exception {
-
-    }
-
-
+    public void passivateObject(Object o) throws Exception {}
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/util/TestUtil.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/util/TestUtil.java
@@ -184,6 +184,7 @@ public class TestUtil {
 
     public static void writeContent(HttpURLConnection urlConn, String content) throws IOException {
         urlConn.getOutputStream().write(content.getBytes(Charsets.UTF_8));
+        urlConn.getOutputStream().flush();
     }
 
     public static HttpURLConnection request(URI baseURI, String path, String method, boolean keepAlive)

--- a/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/util/server/HTTPServerHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/util/server/HTTPServerHandler.java
@@ -35,8 +35,6 @@ import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.UnsupportedEncodingException;
-
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
@@ -53,7 +51,7 @@ public class HTTPServerHandler extends ChannelInboundHandlerAdapter {
 
     private static final Logger logger = LoggerFactory.getLogger(HTTPServerHandler.class);
 
-    private ByteBuf content;
+    private String stringContent;
     private String contentType;
     private int responseStatusCode = 200;
     private HttpRequest req;
@@ -61,7 +59,8 @@ public class HTTPServerHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
 
-        if (content != null) {
+        if (stringContent != null) {
+            ByteBuf content = Unpooled.wrappedBuffer(stringContent.getBytes("UTF-8"));
             if (msg instanceof HttpRequest) {
                 req = (HttpRequest) msg;
             } else if (msg instanceof LastHttpContent) {
@@ -120,13 +119,7 @@ public class HTTPServerHandler extends ChannelInboundHandlerAdapter {
     public void setMessage(String message, String contentType) {
         if (message != null && contentType != null) {
             this.contentType = contentType;
-            try {
-                content = Unpooled.wrappedBuffer(message.getBytes("UTF-8"));
-            } catch (UnsupportedEncodingException e) {
-                logger.error("Encoding not supported", e);
-            }
-        } else {
-            logger.debug("Please specify message and contentType ");
+            stringContent = message;
         }
     }
 


### PR DESCRIPTION
We already have two pooling mechanisms but both have issues.
One has high contention for locks and the other has a connection leak.

Following are the things done.

- Fix the idle connection eviction for inbound and outbound.
- Introduce two new connection pooling techniques. 
  - One for high performance
  - One for cater different types transports needs such as controlling outbound connections. 
- Refactor Sourcehandler, TargetHanlder, ConnectionManager, ChannelUtils.
- Removed using the unnecessary thread pool to send message out. 
- Fix the issue in test server.
- Fix the issue of not cleaning the global connection pool when EventLoops are shutdown.
- Tested with a load test and response assertion tests.
- Fix the issue of not invalidating the connection when connection is closed abruptly.

Re-factored the code but a lot more to do. Doing it gracefully.