### PR TITLE
Add connection properties that doesn't have a mapping

### DIFF
--- a/jms/org.wso2.carbon.transport.jms/src/main/java/org/wso2/carbon/transport/jms/receiver/JMSServerConnector.java
+++ b/jms/org.wso2.carbon.transport.jms/src/main/java/org/wso2/carbon/transport/jms/receiver/JMSServerConnector.java
@@ -203,6 +203,8 @@ public class JMSServerConnector extends ServerConnector {
             String mappedParameter = JMSConstants.MAPPING_PARAMETERS.get(entry.getKey());
             if (mappedParameter != null) {
                 properties.put(mappedParameter, entry.getValue());
+            } else {
+                properties.put(entry.getKey(), entry.getValue());
             }
         }
 


### PR DESCRIPTION
- Add custom connection properties that don't have mappings to the property list passed to the server connector.