### PR TITLE
Fix issue with protocol mismatch

### DIFF
--- a/file/org.wso2.carbon.transport.file-system/src/main/java/org/wso2/carbon/transport/filesystem/connector/server/util/Constants.java
+++ b/file/org.wso2.carbon.transport.file-system/src/main/java/org/wso2/carbon/transport/filesystem/connector/server/util/Constants.java
@@ -24,6 +24,7 @@ package org.wso2.carbon.transport.filesystem.connector.server.util;
 public final class Constants {
 
     public static final String PROTOCOL_FILE_SYSTEM = "fs";
+    public static final String PROTOCOL_FILE = "file";
 
     // meta data of the file
     public static final String META_FILE_SIZE = "file-size";


### PR DESCRIPTION
This PR fixes the above mentioned issue. When getting the protocol from the file's URL, it returned 'file' as the protocol. Since we need to distinguish between 'file' and 'file system', a check was added to set the protocol to 'fs' if the protocol is 'file'.