### PR TITLE
Endpoint timeout support

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Constants.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Constants.java
@@ -240,6 +240,8 @@ public final class Constants {
     public static final String HTTP2_AUTHORITY = ":authority";
     public static final String HTTP2_SCHEME = ":scheme";
 
+    public static final String TARGET_HANDLER = "targetHandler";
+
     private Constants() {
     }
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Constants.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Constants.java
@@ -241,6 +241,7 @@ public final class Constants {
     public static final String HTTP2_SCHEME = ":scheme";
 
     public static final String TARGET_HANDLER = "targetHandler";
+    public static final String IDLE_STATE_HANDLER = "idleStateHandler";
 
     private Constants() {
     }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
@@ -182,7 +182,7 @@ public class HTTPServerChannelInitializer extends ChannelInitializer<SocketChann
         p.addLast("compressor", new HttpContentCompressor());
         p.addLast("chunkWriter", new ChunkedWriteHandler());
         try {
-            int socketIdleTimeout = listenerConfiguration.getSocketIdleTimeout(60000);
+            int socketIdleTimeout = listenerConfiguration.getSocketIdleTimeout(120000);
             p.addLast("idleStateHandler",
                     new IdleStateHandler(socketIdleTimeout, socketIdleTimeout, socketIdleTimeout,
                             TimeUnit.MILLISECONDS));

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/HTTPServerChannelInitializer.java
@@ -33,6 +33,7 @@ import io.netty.util.AsciiString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonTransportInitializer;
+import org.wso2.carbon.transport.http.netty.common.Constants;
 import org.wso2.carbon.transport.http.netty.common.ssl.SSLHandlerFactory;
 import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.carbon.transport.http.netty.config.RequestSizeValidationConfiguration;
@@ -183,7 +184,7 @@ public class HTTPServerChannelInitializer extends ChannelInitializer<SocketChann
         p.addLast("chunkWriter", new ChunkedWriteHandler());
         try {
             int socketIdleTimeout = listenerConfiguration.getSocketIdleTimeout(120000);
-            p.addLast("idleStateHandler",
+            p.addLast(Constants.IDLE_STATE_HANDLER,
                     new IdleStateHandler(socketIdleTimeout, socketIdleTimeout, socketIdleTimeout,
                             TimeUnit.MILLISECONDS));
             p.addLast("handler", new SourceHandler(connectionManager, listenerConfiguration));

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
@@ -195,7 +195,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             pipeline.addLast("ws_handler", webSocketSourceHandler);
 
             // TODO: handle Idle state in WebSocket with configurations.
-            pipeline.remove("idleStateHandler");
+            pipeline.remove(Constants.IDLE_STATE_HANDLER);
             pipeline.remove(this);
 
         } catch (Exception e) {

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientInitializer.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientInitializer.java
@@ -22,14 +22,10 @@ import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
-import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.transport.http.netty.common.ssl.SSLHandlerFactory;
 import org.wso2.carbon.transport.http.netty.config.SenderConfiguration;
-import org.wso2.carbon.transport.http.netty.sender.channel.BootstrapConfiguration;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * A class that responsible for initialize target server pipeline.
@@ -39,14 +35,10 @@ public class HTTPClientInitializer extends ChannelInitializer<SocketChannel> {
     private static final Logger log = LoggerFactory.getLogger(HTTPClientInitializer.class);
 
     private SenderConfiguration senderConfiguration;
-
-    protected static final String HANDLER = "handler";
     private TargetHandler handler;
-    private int soTimeOut;
 
     public HTTPClientInitializer(SenderConfiguration senderConfiguration) {
         this.senderConfiguration = senderConfiguration;
-        soTimeOut = BootstrapConfiguration.getInstance().getSocketTimeout();
     }
 
     @Override
@@ -63,11 +55,8 @@ public class HTTPClientInitializer extends ChannelInitializer<SocketChannel> {
         ch.pipeline().addLast("decoder", new HttpResponseDecoder());
         ch.pipeline().addLast("encoder", new HttpRequestEncoder());
         ch.pipeline().addLast("chunkWriter", new ChunkedWriteHandler());
-        int socketIdleTimeout = senderConfiguration.getSocketIdleTimeout(60000);
-        ch.pipeline().addLast("idleStateHandler",
-                new IdleStateHandler(socketIdleTimeout, socketIdleTimeout, 0, TimeUnit.MILLISECONDS));
         handler = new TargetHandler();
-        ch.pipeline().addLast(HANDLER, handler);
+        ch.pipeline().addLast("targetHandler", handler);
     }
 
     public TargetHandler getTargetHandler() {

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientInitializer.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/HTTPClientInitializer.java
@@ -24,6 +24,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.transport.http.netty.common.Constants;
 import org.wso2.carbon.transport.http.netty.common.ssl.SSLHandlerFactory;
 import org.wso2.carbon.transport.http.netty.config.SenderConfiguration;
 
@@ -56,7 +57,7 @@ public class HTTPClientInitializer extends ChannelInitializer<SocketChannel> {
         ch.pipeline().addLast("encoder", new HttpRequestEncoder());
         ch.pipeline().addLast("chunkWriter", new ChunkedWriteHandler());
         handler = new TargetHandler();
-        ch.pipeline().addLast("targetHandler", handler);
+        ch.pipeline().addLast(Constants.TARGET_HANDLER, handler);
     }
 
     public TargetHandler getTargetHandler() {

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
@@ -104,7 +104,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
                             HTTPTransportContextHolder.getInstance().getHandlerExecutor().
                                     executeAtTargetResponseSending(cMsg);
                         }
-                        targetChannel.getChannel().pipeline().remove("idleStateHandler");
+//                        targetChannel.getChannel().pipeline().remove("idleStateHandler");
                         targetChannel.setRequestWritten(false);
                         connectionManager.returnChannel(targetChannel);
                     } else {
@@ -123,7 +123,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         ctx.close();
-        targetChannel.getChannel().pipeline().remove("idleStateHandler");
+//        targetChannel.getChannel().pipeline().remove("idleStateHandler");
         targetChannel.setRequestWritten(false);
         connectionManager.invalidateTargetChannel(targetChannel);
 

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
@@ -115,7 +115,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
             }
         } else {
             if (msg instanceof HttpResponse) {
-                LOG.warn("Received a response for an obsolete request ");
+                LOG.warn("Received a response for an obsolete request");
             }
             ReferenceCountUtil.release(msg);
         }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
@@ -105,7 +105,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
                             HTTPTransportContextHolder.getInstance().getHandlerExecutor().
                                     executeAtTargetResponseSending(cMsg);
                         }
-                        targetChannel.getChannel().pipeline().remove("idleStateHandler");
+                        targetChannel.getChannel().pipeline().remove(Constants.IDLE_STATE_HANDLER);
                         connectionManager.returnChannel(targetChannel);
                     } else {
                         HttpContent httpContent = (DefaultHttpContent) msg;
@@ -124,7 +124,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         ctx.close();
-        targetChannel.getChannel().pipeline().remove("idleStateHandler");
+        targetChannel.getChannel().pipeline().remove(Constants.IDLE_STATE_HANDLER);
         connectionManager.invalidateTargetChannel(targetChannel);
 
         if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
@@ -227,7 +227,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         if (evt instanceof IdleStateEvent) {
             IdleStateEvent event = (IdleStateEvent) evt;
             if (event.state() == IdleState.READER_IDLE || event.state() == IdleState.WRITER_IDLE) {
-                targetChannel.getChannel().pipeline().remove("idleStateHandler");
+                targetChannel.getChannel().pipeline().remove(Constants.IDLE_STATE_HANDLER);
                 targetChannel.setRequestWritten(false);
                 sendBackTimeOutResponse();
             }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/TargetChannel.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/TargetChannel.java
@@ -27,22 +27,12 @@ import org.wso2.carbon.transport.http.netty.sender.TargetHandler;
  */
 public class TargetChannel {
 
-
     private Channel channel;
-
     private TargetHandler targetHandler;
-
     private HTTPClientInitializer httpClientInitializer;
-
     private HttpRoute httpRoute;
-
     private SourceHandler correlatedSource;
-
     private boolean isRequestWritten;
-
-    public boolean isRequestWritten() {
-        return isRequestWritten;
-    }
 
     public Channel getChannel() {
         return channel;
@@ -83,6 +73,10 @@ public class TargetChannel {
 
     public void setCorrelatedSource(SourceHandler correlatedSource) {
         this.correlatedSource = correlatedSource;
+    }
+
+    public boolean isRequestWritten() {
+        return isRequestWritten;
     }
 
     public void setRequestWritten(boolean isRequestWritten) {

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/TargetChannel.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/TargetChannel.java
@@ -32,7 +32,7 @@ public class TargetChannel {
     private HTTPClientInitializer httpClientInitializer;
     private HttpRoute httpRoute;
     private SourceHandler correlatedSource;
-    private boolean isRequestWritten;
+    private boolean isRequestWritten = false;
 
     public Channel getChannel() {
         return channel;

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -188,7 +188,7 @@ public class ConnectionManager {
                 targetHandler.setConnectionManager(connectionManager);
                 targetHandler.setTargetChannel(targetChannel);
                 int socketIdleTimeout = senderConfiguration.getSocketIdleTimeout(60000);
-                targetChannel.getChannel().pipeline().addBefore("targetHandler", "idleStateHandler",
+                targetChannel.getChannel().pipeline().addBefore(Constants.TARGET_HANDLER, "idleStateHandler",
                         new IdleStateHandler(socketIdleTimeout, socketIdleTimeout, 0, TimeUnit.MILLISECONDS));
                 targetChannel.setRequestWritten(true);
                 ChannelUtils.writeContent(targetChannel.getChannel(), httpRequest, carbonMessage);

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -185,6 +185,9 @@ public class ConnectionManager {
                 targetHandler.setConnectionManager(connectionManager);
                 targetHandler.setTargetChannel(targetChannel);
                 if (ChannelUtils.writeContent(targetChannel.getChannel(), httpRequest, carbonMessage)) {
+//                    int socketIdleTimeout = senderConfiguration.getSocketIdleTimeout(60000);
+//                    targetChannel.getChannel().pipeline().addBefore("targetHandler", "idleStateHandler",
+//                            new IdleStateHandler(socketIdleTimeout, socketIdleTimeout, 0, TimeUnit.MILLISECONDS));
                     targetChannel.setRequestWritten(true); // If request written
                 }
             }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -188,7 +188,7 @@ public class ConnectionManager {
                 targetHandler.setConnectionManager(connectionManager);
                 targetHandler.setTargetChannel(targetChannel);
                 int socketIdleTimeout = senderConfiguration.getSocketIdleTimeout(60000);
-                targetChannel.getChannel().pipeline().addBefore(Constants.TARGET_HANDLER, "idleStateHandler",
+                targetChannel.getChannel().pipeline().addBefore(Constants.TARGET_HANDLER, Constants.IDLE_STATE_HANDLER,
                         new IdleStateHandler(socketIdleTimeout, socketIdleTimeout, 0, TimeUnit.MILLISECONDS));
                 targetChannel.setRequestWritten(true);
                 ChannelUtils.writeContent(targetChannel.getChannel(), httpRequest, carbonMessage);

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.transport.http.netty.sender.TargetHandler;
 import org.wso2.carbon.transport.http.netty.sender.channel.ChannelUtils;
 import org.wso2.carbon.transport.http.netty.sender.channel.TargetChannel;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -189,7 +190,7 @@ public class ConnectionManager {
                 }
             }
         } catch (Exception e) {
-            String msg = "Failed to send the request : " + e.getMessage().toLowerCase();
+            String msg = "Failed to send the request : " + e.getMessage().toLowerCase(Locale.ENGLISH);
             log.error(msg, e);
             MessagingException messagingException = new MessagingException(msg, e, 101500);
             carbonMessage.setMessagingException(messagingException);

--- a/http/org.wso2.carbon.transport.http.netty/src/test/resources/simple-test-config/netty-transports.yml
+++ b/http/org.wso2.carbon.transport.http.netty/src/test/resources/simple-test-config/netty-transports.yml
@@ -93,6 +93,7 @@ listenerConfigurations:
 senderConfigurations:
  -
   id: "http-sender"
+  socketIdleTimeout: 120000
   parameters:
     -
      name: "connection.pool.count"
@@ -123,6 +124,7 @@ senderConfigurations:
   scheme: "https"
   trustStoreFile: "simple-test-config/client-truststore.jks"
   trustStorePass: "wso2carbon"
+  socketIdleTimeout: 120000
   parameters:
     -
      name: "connection.pool.count"


### PR DESCRIPTION
At the moment we can only specify the socket timeout. However, as in our previous ESB, we need an endpoint timeout as well. When the endpoint times out, we do not close the connection but rather return the channel to the pool while sending back a timeout response. 
