### PR TITLE
Avoid copying netty-transport.yml configuration file through feature

### DIFF
--- a/features/http/org.wso2.carbon.transport.http.netty.feature/resources/p2.inf
+++ b/features/http/org.wso2.carbon.transport.http.netty.feature/resources/p2.inf
@@ -1,3 +1,0 @@
-instructions.configure = \
-org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.carbon.transport.http.netty_${feature.version}/conf/,target:${installFolder}/../../../conf/transports/,overwrite:false);\
-org.eclipse.equinox.p2.touchpoint.natives.chmod(targetDir:${installFolder}/../../../conf/transports/,targetFile:netty-transports.yml,permissions:644);


### PR DESCRIPTION
From latest Kernel (5.2.0-m3) onwards, we have run time specific deployment configuration then we cannot copy configuration files to a common location through features. This will leads to exception similar as below. To avoid that I am suggesting the below fix.

Installation failed.
An error occurred while configuring the installed items
 session context was:(profile=editor, phase=org.eclipse.equinox.internal.p2.engine.phases.Configure, operand=null --> [R]org.wso2.carbon.transport.http.netty.feature.group 4.4.17, action=org.eclipse.equinox.internal.p2.touchpoint.natives.actions.CopyAction).
 I/O Error while copying /home/mohan/wso2/source-code/mohan-repo/carbon-analytics/components/distribution/target/carbon-analytics/wso2/editor/../lib/features/org.wso2.carbon.transport.http.netty_4.4.17/conf - see details.
Caused by:  java.io.IOException: Target: /home/mohan/wso2/source-code/mohan-repo/carbon-analytics/components/distribution/target/carbon-analytics/wso2/editor/../../../conf/transports/netty-transports.yml already exists
Application failed, log file location: /home/mohan/wso2/source-code/mohan-repo/carbon-analytics/components/distribution/target/director/configuration/1500918986694.log


