### PR TITLE
Fix for WebSocket Connection Closure issue in Session

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/websocket/WebSocketSessionImpl.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/websocket/WebSocketSessionImpl.java
@@ -76,6 +76,7 @@ public class WebSocketSessionImpl extends WebSocketSessionAdapter {
     public void close(CloseReason closeReason) {
         ctx.channel().writeAndFlush(new CloseWebSocketFrame(closeReason.getCloseCode().getCode(),
                                                     closeReason.getReasonPhrase()));
+        ctx.channel().close();
     }
 
     @Override


### PR DESCRIPTION
This PR resolves [[WebSocket] Close function malfunctions in Connection store](https://github.com/ballerinalang/ballerina/issues/3047).

_Note: After merging and releasing this please change the carbon-transport version of [ballerina-parent](https://github.com/ballerinalang/ballerina-parent) to 4.4.23 to become this change effective for the above issue_