### PR TITLE
Modify Quartz version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
         <commons-vfs2.wso2.version>2.0-wso2v15</commons-vfs2.wso2.version>
         <commons-vfs2.wso2.version.range>[2.0.0, 3.0.0)</commons-vfs2.wso2.version.range>
         <org.apache.commons.pool2.version>2.4.2</org.apache.commons.pool2.version>
-        <quartz.version>2.3.0.wso2v1</quartz.version>
+        <quartz.version>2.3.0.wso2v2</quartz.version>
         <quartz.version.range>[2.3.0, 3.0.0)</quartz.version.range>
         <commons-net.version>3.6</commons-net.version>
 


### PR DESCRIPTION
This PR will modify the Quartz bundle version used to 2.3.0.wso2v2 to make use of the corrected Quartz bundle. 