### PR TITLE
Add meta data retrieval for files and fix formatting issues

### DIFF
--- a/file/org.wso2.carbon.transport.file/src/main/java/org/wso2/carbon/transport/file/connector/server/util/Constants.java
+++ b/file/org.wso2.carbon.transport.file/src/main/java/org/wso2/carbon/transport/file/connector/server/util/Constants.java
@@ -49,6 +49,10 @@ public final class Constants {
     public static final String FILE_ROTATE = "FILE_ROTATE";
     public static final String FILE_TRANSPORT_EVENT_NAME = "FILE_TRANSPORT_EVENT_NAME";
 
+    // file meta data
+    public static final String FILE_META_SIZE = "file-size";
+    public static final String FILE_META_LAST_MODIFIED_TIME = "last-modified-time";
+
     private Constants() {
     }
 


### PR DESCRIPTION
This PR adds the support for getting a file's meta data. When starting to process a file, it first build a Carbon Message with the meta data of the file set as properties and send this to the associated Message Processor. 