### PR TITLE
Fix ResponseContentWriter issue, Improve transport thread configuration

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpWsConnectorFactoryImpl.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpWsConnectorFactoryImpl.java
@@ -40,6 +40,16 @@ import java.util.Map;
  */
 public class HttpWsConnectorFactoryImpl implements HttpWsConnectorFactory {
 
+    private int serverSocketThreads = Runtime.getRuntime().availableProcessors();
+    private int childSocketThreads = Runtime.getRuntime().availableProcessors() * 2;
+
+    public HttpWsConnectorFactoryImpl() {}
+
+    public HttpWsConnectorFactoryImpl(int serverSocketThreads, int childSocketThreads) {
+        this.serverSocketThreads = serverSocketThreads;
+        this.childSocketThreads = childSocketThreads;
+    }
+
     @Override
     public ServerConnector createServerConnector(ServerBootstrapConfiguration serverBootstrapConfiguration,
             ListenerConfiguration listenerConfig) {
@@ -48,8 +58,7 @@ public class HttpWsConnectorFactoryImpl implements HttpWsConnectorFactory {
         serverConnectorBootstrap.addSecurity(listenerConfig.getSslConfig());
         serverConnectorBootstrap.addIdleTimeout(listenerConfig.getSocketIdleTimeout(120000));
         serverConnectorBootstrap.addHttpTraceLogHandler(listenerConfig.isHttpTraceLogEnabled());
-        serverConnectorBootstrap.addThreadPools(Runtime.getRuntime().availableProcessors(),
-                Runtime.getRuntime().availableProcessors() * 2);
+        serverConnectorBootstrap.addThreadPools(serverSocketThreads, childSocketThreads);
 
         return serverConnectorBootstrap.getServerConnector(listenerConfig.getHost(), listenerConfig.getPort());
     }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -190,7 +190,6 @@ public class ConnectionManager {
      * Connection pool management policies for  target channels.
      */
     public enum PoolManagementPolicy {
-        GLOBAL_ENDPOINT_CONNECTION_CACHING,
         LOCK_DEFAULT_POOLING,
     }
 


### PR DESCRIPTION
In addition to those this pull request also fixes the issue with In/Out streams provided by the carbon message. 

Please note that there are some commented code. Those code were written to add handlers to intercept transport code at certain point. This was originally done for some customers request. Need to check the validity of the requirement once again and re-enable it in a better way.