### PR TITLE
Remove header impl, introduce transport interceptors

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Util.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Util.java
@@ -102,12 +102,11 @@ public class Util {
 
         DefaultHttpResponse outgoingResponse = new DefaultHttpResponse(httpVersion, httpResponseStatus, false);
 
-        Headers headers = msg.getHeaders();
         if (connectionCloseAfterResponse) {
-            headers.set(Constants.HTTP_CONNECTION, Constants.CONNECTION_CLOSE);
+            msg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_CLOSE);
         }
 
-        Util.setHeaders(outgoingResponse, headers);
+        outgoingResponse.headers().setAll(msg.getHeaders());
 
         return outgoingResponse;
     }
@@ -131,8 +130,8 @@ public class Util {
         }
         HttpRequest outgoingRequest = new DefaultHttpRequest(httpVersion, httpMethod,
                 (String) msg.getProperty(Constants.TO), false);
-        Headers headers = msg.getHeaders();
-        Util.setHeaders(outgoingRequest, headers);
+        HttpHeaders headers = msg.getHeaders();
+        outgoingRequest.headers().setAll(headers);
         return outgoingRequest;
     }
 

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HTTPTransportActivator.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HTTPTransportActivator.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.transport.http.netty.internal;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.wso2.carbon.messaging.handler.HandlerExecutor;
 
 /**
  * OSGi BundleActivator of the Netty transport component.

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HTTPTransportContextHolder.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HTTPTransportContextHolder.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonMessageProcessor;
 import org.wso2.carbon.messaging.TransportListenerManager;
-import org.wso2.carbon.messaging.handler.HandlerExecutor;
 import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
 
 import java.util.HashMap;

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HTTPTransportServiceComponent.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HTTPTransportServiceComponent.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.kernel.startupresolver.RequiredCapabilityListener;
 import org.wso2.carbon.messaging.CarbonMessageProcessor;
 import org.wso2.carbon.messaging.TransportListenerManager;
-import org.wso2.carbon.messaging.handler.MessagingHandler;
 
 /**
  * Declarative service component for the Netty transport. This handles registration &amp; unregistration of relevant

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HandlerExecutor.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HandlerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HandlerExecutor.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/HandlerExecutor.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.transport.http.netty.internal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.messaging.CarbonCallback;
+import org.wso2.carbon.transport.http.netty.message.HTTPCarbonMessage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The class that is responsible for engaging all the interceptors.
+ */
+public class HandlerExecutor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(org.wso2.carbon.messaging.handler.HandlerExecutor.class);
+    private Map<String, MessagingHandler> handlers = new HashMap<>();
+
+    public boolean executeRequestContinuationValidator(HTTPCarbonMessage carbonMessage, CarbonCallback callback) {
+        try {
+            handlers.forEach((k, v) -> v.validateRequestContinuation(carbonMessage, callback));
+            for (Map.Entry<String, MessagingHandler> messagingHandlerEntry : handlers.entrySet()) {
+                if (!messagingHandlerEntry.getValue()
+                        .validateRequestContinuation(carbonMessage, callback)) {
+                    return false;
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Source connection initiation ", e);
+        }
+        return true;
+    }
+
+    public void executeAtSourceConnectionInitiation(String metadata) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtSourceConnectionInitiation(metadata));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Source connection initiation ", e);
+        }
+    }
+
+    public void executeAtSourceConnectionTermination(String metadata) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtSourceConnectionTermination(metadata));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Source connection termination ", e);
+        }
+    }
+
+    public void executeAtSourceRequestReceiving(HTTPCarbonMessage carbonMessage) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtSourceRequestReceiving(carbonMessage));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Source request receiving ", e);
+        }
+    }
+
+    public void executeAtSourceRequestSending(HTTPCarbonMessage carbonMessage) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtSourceRequestSending(carbonMessage));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Source request sending ", e);
+        }
+    }
+
+    public void executeAtTargetRequestReceiving(HTTPCarbonMessage carbonMessage) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtTargetRequestReceiving(carbonMessage));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Target request receiving ", e);
+        }
+    }
+
+    public void executeAtTargetRequestSending(HTTPCarbonMessage carbonMessage) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtTargetRequestSending(carbonMessage));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Target request sending ", e);
+        }
+    }
+
+    public void executeAtTargetResponseReceiving(HTTPCarbonMessage carbonMessage) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtTargetResponseReceiving(carbonMessage));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Target response receiving ", e);
+        }
+    }
+
+    public void executeAtTargetResponseSending(HTTPCarbonMessage carbonMessage) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtTargetResponseSending(carbonMessage));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Target response sending ", e);
+        }
+    }
+
+    public void executeAtSourceResponseReceiving(HTTPCarbonMessage carbonMessage) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtSourceResponseReceiving(carbonMessage));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Source response receiving ", e);
+        }
+    }
+
+    public void executeAtSourceResponseSending(HTTPCarbonMessage carbonMessage) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtSourceResponseSending(carbonMessage));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Source response sending ", e);
+        }
+    }
+
+    public void executeAtTargetConnectionInitiation(String metadata) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtTargetConnectionInitiation(metadata));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Target connection initiation ", e);
+        }
+    }
+
+    public void executeAtTargetConnectionTermination(String metadata) {
+        try {
+            handlers.forEach((k, v) -> v.invokeAtTargetConnectionTermination(metadata));
+        } catch (Exception e) {
+            LOG.error("Error while executing handler at Target connection termination ", e);
+        }
+    }
+
+    public void addHandler(MessagingHandler messagingHandler) {
+        handlers.put(messagingHandler.handlerName(), messagingHandler);
+        LOG.info("A new handler named " + messagingHandler.handlerName() + " is added to the Handler Executor");
+    }
+
+    public void removeHandler(MessagingHandler messagingHandler) {
+        handlers.remove(messagingHandler.handlerName());
+        LOG.info("Handler named " + messagingHandler.handlerName() + " is removed from the Handler Executor");
+    }
+}

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/MessagingHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/MessagingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/MessagingHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/internal/MessagingHandler.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.transport.http.netty.internal;
+
+import org.wso2.carbon.messaging.CarbonCallback;
+import org.wso2.carbon.transport.http.netty.message.HTTPCarbonMessage;
+
+/**
+ * Interface for MessagingHandler.
+ */
+public interface MessagingHandler {
+
+    /**
+     * Invoked when source request's headers are received at the source handler.
+     *
+     * @param carbonMessage client request with headers
+     * @param callback      response callback
+     * @return true to continue the message flow,
+     *         false to discontinue the flow and done the callback with response message.
+     */
+    boolean validateRequestContinuation(HTTPCarbonMessage carbonMessage, CarbonCallback callback);
+
+    /**
+     * Invoked when source connection is initiated.
+     *
+     * @param metadata unique string key to identify the connection
+     */
+    void invokeAtSourceConnectionInitiation(String metadata);
+
+    /**
+     * Invoked when source connection is terminated.
+     *
+     * @param metadata unique string key to identify the connection
+     */
+    void invokeAtSourceConnectionTermination(String metadata);
+
+    /**
+     * Invoked when target connection is initiated.
+     *
+     * @param metadata unique string key to identify the connection
+     */
+    void invokeAtTargetConnectionInitiation(String metadata);
+
+    /**
+     * Invoked when target connection is terminated.
+     *
+     * @param metadata unique string key to identify the connection
+     */
+    void invokeAtTargetConnectionTermination(String metadata);
+
+    /**
+     * Invoked when source request is started receiving at source handler.
+     *
+     * @param carbonMessage newly created carbon message.
+     */
+    void invokeAtSourceRequestReceiving(HTTPCarbonMessage carbonMessage);
+
+    /**
+     * Invoked when source request is started sending to the message processor.
+     *
+     * @param carbonMessage client request (i.e headers, property and message body)
+     */
+    void invokeAtSourceRequestSending(HTTPCarbonMessage carbonMessage);
+
+    /**
+     * Invoked when the request is received again to the transport level after being processed at message processor.
+     *
+     * @param carbonMessage processed (or mediated) request (i.e headers, properties and message body)
+     */
+    void invokeAtTargetRequestReceiving(HTTPCarbonMessage carbonMessage);
+
+    /**
+     * Invoked when the request is started sending to the backend.
+     *
+     * @param carbonMessage sent request (i.e the message is already had started to send to backend)
+     *                      So no message body will be available. Even though the headers and properties are available,
+     *                      manipulating them won't change the request send to the back end (because the headers are
+     *                      already been send to the backend)
+     */
+    void invokeAtTargetRequestSending(HTTPCarbonMessage carbonMessage);
+
+    /**
+     * Invoked when target response is started receiving at target handler.
+     *
+     * @param carbonMessage newly created carbon message.
+     */
+    void invokeAtTargetResponseReceiving(HTTPCarbonMessage carbonMessage);
+
+    /**
+     * Invoked when target response is started sending to the message processor.
+     *
+     * @param carbonMessage target response (i.e headers, property and message body)
+     */
+    void invokeAtTargetResponseSending(HTTPCarbonMessage carbonMessage);
+
+    /**
+     * Invoked when the response is received again to the transport level after being processed at message processor.
+     *
+     * @param carbonMessage processed (or mediated) response (i.e headers, properties and message body)
+     */
+    void invokeAtSourceResponseReceiving(HTTPCarbonMessage carbonMessage);
+
+    /**
+     * Invoked when the response is started sending to the client.
+     *
+     * @param carbonMessage sent response (i.e with empty message body.
+     *                      similar carbon message to}
+     */
+    void invokeAtSourceResponseSending(HTTPCarbonMessage carbonMessage);
+
+    /**
+     * Gives handler name.
+     *
+     * @return handler name
+     */
+    String handlerName();
+}

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/ResponseContentWriter.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/ResponseContentWriter.java
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http.LastHttpContent;
 import org.wso2.carbon.messaging.CarbonMessage;
 import org.wso2.carbon.messaging.Writer;
 import org.wso2.carbon.transport.http.netty.common.Constants;
-import org.wso2.carbon.transport.http.netty.internal.HTTPTransportContextHolder;
 
 import java.nio.ByteBuffer;
 
@@ -36,6 +35,7 @@ import java.nio.ByteBuffer;
  * A class which wraps Inbound Channel Handler ctx and write content directly to netty IO works.
  */
 public class ResponseContentWriter implements Writer {
+    // TODO: This class not needed anymore. This is here only for references purposes and will remove in next release.
 
     private ChannelHandlerContext channelHandlerContext;
 
@@ -55,10 +55,10 @@ public class ResponseContentWriter implements Writer {
     @Override
     public void writeLastContent(CarbonMessage carbonMessage) {
         ChannelFuture future = channelHandlerContext.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
-        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
-            HTTPTransportContextHolder.getInstance().getHandlerExecutor().
-                    executeAtSourceResponseSending(carbonMessage);
-        }
+//        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+//            HTTPTransportContextHolder.getInstance().getHandlerExecutor().
+//                    executeAtSourceResponseSending(carbonMessage);
+//        }
         String connection = carbonMessage.getHeader(Constants.HTTP_CONNECTION);
         if (connection != null && HTTP_CONNECTION_CLOSE.equalsIgnoreCase(connection)) {
             future.addListener(ChannelFutureListener.CLOSE);

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/ServerConnectorBootstrap.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/ServerConnectorBootstrap.java
@@ -25,7 +25,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.messaging.handler.HandlerExecutor;
 import org.wso2.carbon.transport.http.netty.common.Util;
 import org.wso2.carbon.transport.http.netty.common.ssl.SSLConfig;
 import org.wso2.carbon.transport.http.netty.config.RequestSizeValidationConfiguration;
@@ -33,6 +32,7 @@ import org.wso2.carbon.transport.http.netty.contract.ServerConnector;
 import org.wso2.carbon.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.carbon.transport.http.netty.contractimpl.HttpWsServerConnectorFuture;
 import org.wso2.carbon.transport.http.netty.internal.HTTPTransportContextHolder;
+import org.wso2.carbon.transport.http.netty.internal.HandlerExecutor;
 
 import java.net.InetSocketAddress;
 

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/SourceHandler.java
@@ -35,7 +35,6 @@ import org.apache.commons.pool.impl.GenericObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.transport.http.netty.common.Constants;
-import org.wso2.carbon.transport.http.netty.common.Util;
 import org.wso2.carbon.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.carbon.transport.http.netty.contractimpl.HttpResponseListener;
 import org.wso2.carbon.transport.http.netty.internal.HTTPTransportContextHolder;
@@ -54,7 +53,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
 
     protected ChannelHandlerContext ctx;
     private HTTPCarbonMessage sourceReqCmsg;
-    private Map<String, GenericObjectPool> targetChannelPool = new ConcurrentHashMap<>();
+    private Map<String, GenericObjectPool> targetChannelPool;
     private ServerConnectorFuture serverConnectorFuture;
     private String interfaceId;
 
@@ -62,6 +61,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             throws Exception {
         this.serverConnectorFuture = serverConnectorFuture;
         this.interfaceId = interfaceId;
+        this.targetChannelPool = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -90,11 +90,10 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             ByteBuf content = ((FullHttpMessage) msg).content();
             sourceReqCmsg.addHttpContent(new DefaultLastHttpContent(content));
             sourceReqCmsg.setEndOfMsgAdded(true);
-            // TODO: Revisit when the refactor is complete
-//            if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
-//                HTTPTransportContextHolder.getInstance().getHandlerExecutor()
-//             .executeAtSourceRequestSending(sourceReqCmsg);
-//            }
+            if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+                HTTPTransportContextHolder.getInstance().getHandlerExecutor()
+                                            .executeAtSourceRequestSending(sourceReqCmsg);
+            }
 
         } else if (msg instanceof HttpRequest) {
             HttpRequest httpRequest = (HttpRequest) msg;
@@ -108,11 +107,10 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
                     sourceReqCmsg.addHttpContent(httpContent);
                     if (msg instanceof LastHttpContent) {
                         sourceReqCmsg.setEndOfMsgAdded(true);
-                        // TODO: Revisit when the refactor is complete
-//                        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
-//                            HTTPTransportContextHolder.getInstance().getHandlerExecutor().
-//                                    executeAtSourceRequestSending(sourceReqCmsg);
-//                        }
+                        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+                            HTTPTransportContextHolder.getInstance().getHandlerExecutor().
+                                    executeAtSourceRequestSending(sourceReqCmsg);
+                        }
                         sourceReqCmsg = null;
                     }
                 }
@@ -124,11 +122,11 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
     //immediately
     protected void notifyRequestListener(HTTPCarbonMessage httpRequestMsg, ChannelHandlerContext ctx)
             throws URISyntaxException {
-        // TODO: Revisit when the refactor is complete
-//        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
-//            HTTPTransportContextHolder.getInstance().getHandlerExecutor().
-//                    executeAtSourceRequestReceiving(httpRequestMsg);
-//        }
+
+        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+            HTTPTransportContextHolder.getInstance().getHandlerExecutor().
+                    executeAtSourceRequestReceiving(httpRequestMsg);
+        }
 
 //        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
 //
@@ -140,6 +138,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
 //                    });
 //
 //        }
+
         boolean continueRequest = true;
         if (continueRequest) {
             if (serverConnectorFuture != null) {
@@ -192,13 +191,13 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
     }
 
     protected HTTPCarbonMessage setupCarbonMessage(HttpMessage httpMessage) throws URISyntaxException {
-        sourceReqCmsg = new HTTPCarbonMessage();
-        boolean isSecuredConnection = false;
-        // TODO: Revisit when the refactor is complete
-//        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
-//            HTTPTransportContextHolder.getInstance()
-//              .getHandlerExecutor().executeAtSourceRequestReceiving(sourceReqCmsg);
-//        }
+
+        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+            HTTPTransportContextHolder.getInstance()
+              .getHandlerExecutor().executeAtSourceRequestReceiving(sourceReqCmsg);
+        }
+
+        sourceReqCmsg = new HTTPCarbonMessage(httpMessage);
 
         HttpRequest httpRequest = (HttpRequest) httpMessage;
         sourceReqCmsg.setProperty(Constants.CHNL_HNDLR_CTX, this.ctx);
@@ -210,15 +209,16 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         sourceReqCmsg.setProperty(org.wso2.carbon.messaging.Constants.LISTENER_PORT, localAddress.getPort());
         sourceReqCmsg.setProperty(org.wso2.carbon.messaging.Constants.LISTENER_INTERFACE_ID, interfaceId);
         sourceReqCmsg.setProperty(org.wso2.carbon.messaging.Constants.PROTOCOL, Constants.HTTP_SCHEME);
+
+        boolean isSecuredConnection = false;
         if (ctx.channel().pipeline().get(Constants.SSL_HANDLER) != null) {
             isSecuredConnection = true;
         }
         sourceReqCmsg.setProperty(Constants.IS_SECURED_CONNECTION, isSecuredConnection);
-        sourceReqCmsg.setProperty(Constants.LOCAL_ADDRESS, ctx.channel().localAddress());
 
+        sourceReqCmsg.setProperty(Constants.LOCAL_ADDRESS, ctx.channel().localAddress());
         sourceReqCmsg.setProperty(Constants.REQUEST_URL, httpRequest.getUri());
         sourceReqCmsg.setProperty(Constants.TO, httpRequest.getUri());
-        sourceReqCmsg.setHeaders(Util.getHeaders(httpRequest).getAll());
         //Added protocol name as a string
 
         return sourceReqCmsg;

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2SourceHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/listener/http2/HTTP2SourceHandler.java
@@ -22,8 +22,11 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
@@ -210,7 +213,9 @@ public final class HTTP2SourceHandler extends Http2ConnectionHandler implements 
     protected HTTPCarbonMessage setupCarbonMessage(int streamId, Http2Headers headers) {
 
         // Construct new HTTP carbon message and put into stream id request map
-        HTTPCarbonMessage cMsg = new HTTPCarbonMessage();
+        // TODO: This fix is temporary and we need to revisit this and the entire http2 implementation.
+        HTTPCarbonMessage cMsg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.GET, ""));
         cMsg.setProperty(Constants.PORT, ((InetSocketAddress) ctx.channel().remoteAddress()).getPort());
         cMsg.setProperty(Constants.HOST, ((InetSocketAddress) ctx.channel().remoteAddress()).getHostName());
         cMsg.setProperty(Constants.SCHEME, listenerConfiguration.getScheme());

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/TargetHandler.java
@@ -18,8 +18,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
@@ -28,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.exceptions.MessagingException;
 import org.wso2.carbon.transport.http.netty.common.Constants;
-import org.wso2.carbon.transport.http.netty.common.Util;
 import org.wso2.carbon.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.carbon.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.carbon.transport.http.netty.message.HTTPCarbonMessage;
@@ -37,8 +40,6 @@ import org.wso2.carbon.transport.http.netty.sender.channel.pool.ConnectionManage
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A class responsible for handling responses coming from BE.
@@ -48,16 +49,13 @@ import java.util.Map;
  *
  */
 public class TargetHandler extends ChannelInboundHandlerAdapter {
-    protected static final Logger LOG = LoggerFactory.getLogger(TargetHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TargetHandler.class);
 
     private HttpResponseFuture httpResponseFuture;
     private HTTPCarbonMessage targetRespMsg;
     private ConnectionManager connectionManager;
     private TargetChannel targetChannel;
     private HTTPCarbonMessage incomingMsg;
-
-    public TargetHandler() {
-    }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
@@ -76,10 +74,10 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
             if (msg instanceof HttpResponse) {
                 targetRespMsg = setUpCarbonMessage(ctx, msg);
                 // TODO: Revisit all of these after the refactor
-//                if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
-//                    HTTPTransportContextHolder.getInstance().getHandlerExecutor().
-//                            executeAtTargetResponseReceiving(targetRespMsg);
-//                }
+                if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+                    HTTPTransportContextHolder.getInstance().getHandlerExecutor().
+                            executeAtTargetResponseReceiving(targetRespMsg);
+                }
                 if (this.httpResponseFuture != null) {
                     try {
                         httpResponseFuture.notifyHttpListener(targetRespMsg);
@@ -96,10 +94,10 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
                     if (msg instanceof LastHttpContent) {
                         targetRespMsg.setEndOfMsgAdded(true);
                         targetRespMsg = null;
-//                        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
-//                            HTTPTransportContextHolder.getInstance().getHandlerExecutor().
-//                                    executeAtTargetResponseSending(targetRespMsg);
-//                        }
+                        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+                            HTTPTransportContextHolder.getInstance().getHandlerExecutor().
+                                    executeAtTargetResponseSending(targetRespMsg);
+                        }
                         targetChannel.getChannel().pipeline().remove(Constants.IDLE_STATE_HANDLER);
                         connectionManager.returnChannel(targetChannel);
                     }
@@ -111,6 +109,27 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
             }
             ReferenceCountUtil.release(msg);
         }
+    }
+
+    private HTTPCarbonMessage setUpCarbonMessage(ChannelHandlerContext ctx, Object msg) {
+        targetRespMsg = new HTTPCarbonMessage((HttpMessage) msg);
+        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
+            HTTPTransportContextHolder.getInstance().getHandlerExecutor()
+                                    .executeAtTargetResponseReceiving(targetRespMsg);
+        }
+
+        targetRespMsg.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
+                org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
+        HttpResponse httpResponse = (HttpResponse) msg;
+        targetRespMsg.setProperty(Constants.HTTP_STATUS_CODE, httpResponse.getStatus().code());
+
+        //copy required properties for service chaining from incoming carbon message to the response carbon message
+        //copy shared worker pool
+        targetRespMsg.setProperty(Constants.EXECUTOR_WORKER_POOL, incomingMsg
+                .getProperty(Constants.EXECUTOR_WORKER_POOL));
+        //TODO copy mandatory properties from previous message if needed
+
+        return targetRespMsg;
     }
 
     @Override
@@ -142,64 +161,8 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         this.targetChannel = targetChannel;
     }
 
-    private void sendBackTimeOutResponse() {
-        String payload = "<errorMessage>" + "ReadTimeoutException occurred for endpoint " + targetChannel.
-                getHttpRoute().toString() + "</errorMessage>";
-        if (httpResponseFuture != null) {
-            try {
-                httpResponseFuture.notifyHttpListener(createErrorMessage(payload));
-            } catch (Exception e) {
-                LOG.error("Error while notifying response to listener ", e);
-            }
-        } else {
-            LOG.error("Cannot correlate callback with request callback is null ");
-        }
-    }
-
-    private HTTPCarbonMessage setUpCarbonMessage(ChannelHandlerContext ctx, Object msg) {
-        targetRespMsg = new HTTPCarbonMessage();
-//        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
-//            HTTPTransportContextHolder.getInstance().getHandlerExecutor()
-        // .executeAtTargetResponseReceiving(targetRespMsg);
-//        }
-
-        targetRespMsg.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
-                org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
-        HttpResponse httpResponse = (HttpResponse) msg;
-
-        targetRespMsg.setProperty(Constants.HTTP_STATUS_CODE, httpResponse.getStatus().code());
-        targetRespMsg.setHeaders(Util.getHeaders(httpResponse).getAll());
-
-        //copy required properties for service chaining from incoming carbon message to the response carbon message
-        //copy shared worker pool
-        targetRespMsg.setProperty(Constants.EXECUTOR_WORKER_POOL, incomingMsg
-                .getProperty(Constants.EXECUTOR_WORKER_POOL));
-        //TODO copy mandatory properties from previous message if needed
-
-        return targetRespMsg;
-
-    }
-
-    private HTTPCarbonMessage createErrorMessage(String payload) {
-        HTTPCarbonMessage response = new HTTPCarbonMessage();
-
-        response.addMessageBody(ByteBuffer.wrap(payload.getBytes(Charset.defaultCharset())));
-        response.setEndOfMsgAdded(true);
-        byte[] errorMessageBytes = payload.getBytes(Charset.defaultCharset());
-
-        Map<String, String> transportHeaders = new HashMap<>();
-        transportHeaders.put(Constants.HTTP_CONTENT_TYPE, Constants.TEXT_XML);
-        transportHeaders.put(Constants.HTTP_CONTENT_LENGTH, (String.valueOf(errorMessageBytes.length)));
-
-        response.setHeaders(transportHeaders);
-
-        response.setProperty(Constants.HTTP_STATUS_CODE, 504);
-        response.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
-                org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
-        MessagingException messagingException = new MessagingException("read timeout", 101504);
-        response.setMessagingException(messagingException);
-        return response;
-
+    public HttpResponseFuture getHttpResponseFuture() {
+        return httpResponseFuture;
     }
 
     @Override
@@ -221,7 +184,38 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         }
     }
 
-    public HttpResponseFuture getHttpResponseFuture() {
-        return httpResponseFuture;
+    private void sendBackTimeOutResponse() {
+        String payload = "<errorMessage>" + "ReadTimeoutException occurred for endpoint " + targetChannel.
+                getHttpRoute().toString() + "</errorMessage>";
+        if (httpResponseFuture != null) {
+            try {
+                httpResponseFuture.notifyHttpListener(createErrorMessage(payload));
+            } catch (Exception e) {
+                LOG.error("Error while notifying response to listener ", e);
+            }
+        } else {
+            LOG.error("Cannot correlate callback with request callback is null ");
+        }
+    }
+
+    private HTTPCarbonMessage createErrorMessage(String payload) {
+
+        HTTPCarbonMessage response = new HTTPCarbonMessage(new DefaultHttpResponse(HttpVersion.HTTP_1_1,
+                HttpResponseStatus.INTERNAL_SERVER_ERROR));
+
+        response.addMessageBody(ByteBuffer.wrap(payload.getBytes(Charset.defaultCharset())));
+        response.setEndOfMsgAdded(true);
+        byte[] errorMessageBytes = payload.getBytes(Charset.defaultCharset());
+
+        response.setHeader(Constants.HTTP_CONTENT_TYPE, Constants.TEXT_XML);
+        response.setHeader(Constants.HTTP_CONTENT_LENGTH, (String.valueOf(errorMessageBytes.length)));
+
+        response.setProperty(Constants.HTTP_STATUS_CODE, 504);
+        response.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
+                org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
+        MessagingException messagingException = new MessagingException("read timeout", 101504);
+        response.setMessagingException(messagingException);
+        return response;
+
     }
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/contentaware/ResponseStreamingWithoutBufferingListener.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/contentaware/ResponseStreamingWithoutBufferingListener.java
@@ -19,7 +19,10 @@
 
 package org.wso2.carbon.transport.http.netty.contentaware;
 
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.transport.http.netty.common.Constants;
@@ -41,7 +44,8 @@ public class ResponseStreamingWithoutBufferingListener implements HttpConnectorL
     @Override
     public void onMessage(HTTPCarbonMessage httpRequestMessage) {
         executor.execute(() -> {
-            HTTPCarbonMessage cMsg = new HTTPCarbonMessage();
+            HTTPCarbonMessage cMsg = new HTTPCarbonMessage(new DefaultHttpResponse(HttpVersion.HTTP_1_1,
+                    HttpResponseStatus.OK));
             cMsg.setHeader(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
             cMsg.setHeader(HttpHeaders.Names.TRANSFER_ENCODING, HttpHeaders.Values.CHUNKED);
             cMsg.setHeader(HttpHeaders.Names.CONTENT_TYPE, Constants.TEXT_PLAIN);

--- a/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/https/HTTPSClientTestCase.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/https/HTTPSClientTestCase.java
@@ -18,6 +18,9 @@
 
 package org.wso2.carbon.transport.http.netty.https;
 
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
@@ -70,7 +73,8 @@ public class HTTPSClientTestCase {
     @Test
     public void testHttpsGet() {
         try {
-            HTTPCarbonMessage msg = new HTTPCarbonMessage();
+            HTTPCarbonMessage msg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                    HttpMethod.GET, ""));
             msg.setProperty("PORT", TestUtil.TEST_HTTPS_SERVER_PORT);
             msg.setProperty("PROTOCOL", "https");
             msg.setProperty("HOST", "localhost");


### PR DESCRIPTION
With the new refactor there is no need for a header implementation in HttpCarbonMessage. We can simply use netty's implementation. 

With the first phase of the refactor we removed transport level interceptors we had. With this PR I have re-enabled them.