### PR TITLE
Adding HSTS and HPKP headers to the response

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Constants.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/common/Constants.java
@@ -121,6 +121,12 @@ public final class Constants {
 
     public static final String RESPONSE_CALLBACK = "RESPONSE_CALLBACK";
 
+    public static final String HTTP_STRICT_TRANSPORT_SECURITY_HEADER = "Strict-Transport-Security";
+
+    public static final String HTTP_PUBLIC_KEY_PINS_HEADER = "Public-Key-Pins";
+
+    public static final String HTTPS = "https";
+
     public static final String HOST = "HOST";
 
     public static final String PORT = "PORT";

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/config/ListenerConfiguration.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/config/ListenerConfiguration.java
@@ -28,7 +28,6 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 
-
 /**
  * JAXB representation of a transport listener.
  */
@@ -37,10 +36,17 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 public class ListenerConfiguration {
 
     public static final String DEFAULT_KEY = "default";
-
+    public static final String DEFAULT_SCHEME = "https";
+    public static final String DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE = "max-age=15768000;" +
+            " includeSubDomains";
+    public static final String DEFAULT_PUBLIC_KEY_PINS_HEADER_VALUE =
+            "pin-sha256='2pCcYrG90hDFxwOCsVya7wpbQjqhBy3OPsFyyT+7108='; max-age=15766000; includeSubDomains";
+    /*The key used here is the public key of the default wso2carbon certificate. It is imported as a default value
+    when running TransportSecurityHeadersTestCase*/
     public static ListenerConfiguration getDefault() {
         ListenerConfiguration defaultConfig;
-        defaultConfig = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080);
+        defaultConfig = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080, DEFAULT_SCHEME,
+                DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE, DEFAULT_PUBLIC_KEY_PINS_HEADER_VALUE);
         return defaultConfig;
     }
 
@@ -83,6 +89,12 @@ public class ListenerConfiguration {
     @XmlAttribute
     private String messageProcessorId;
 
+    @XmlAttribute
+    private String strictTransportSecurityHeader;
+
+    @XmlAttribute
+    private String publicKeyPinsHeader;
+
     @XmlElementWrapper(name = "parameters")
     @XmlElement(name = "parameter")
     private List<Parameter> parameters = getDefaultParameters();
@@ -94,6 +106,16 @@ public class ListenerConfiguration {
         this.id = id;
         this.host = host;
         this.port = port;
+    }
+
+    public ListenerConfiguration(String id, String host, int port, String scheme, String hstsHeader,
+                                 String hpkpHeader) {
+        this.id = id;
+        this.host = host;
+        this.port = port;
+        this.scheme = scheme;
+        this.strictTransportSecurityHeader = hstsHeader;
+        this.publicKeyPinsHeader = hpkpHeader;
     }
 
     public String getCertPass() {
@@ -166,6 +188,22 @@ public class ListenerConfiguration {
 
     public void setHttp2(boolean http2) {
         this.http2 = http2;
+    }
+
+    public String getStrictTransportSecurityHeader() {
+        return strictTransportSecurityHeader;
+    }
+
+    public void setStrictTransportSecurityHeader(String strictTransportSecurityHeader) {
+        this.strictTransportSecurityHeader = strictTransportSecurityHeader;
+    }
+
+    public String getPublicKeyPinsHeader() {
+        return publicKeyPinsHeader;
+    }
+
+    public void setPublicKeyPinsHeader(String publicKeyPinsHeader) {
+        this.publicKeyPinsHeader = publicKeyPinsHeader;
     }
 
     public List<Parameter> getParameters() {

--- a/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/security/TransportSecurityHeadersProcessor.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/security/TransportSecurityHeadersProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.transport.http.netty.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.wso2.carbon.messaging.CarbonCallback;
+import org.wso2.carbon.messaging.CarbonMessage;
+import org.wso2.carbon.messaging.CarbonMessageProcessor;
+import org.wso2.carbon.messaging.ClientConnector;
+import org.wso2.carbon.messaging.TransportSender;
+import org.wso2.carbon.messaging.exceptions.ClientConnectorException;
+import org.wso2.carbon.transport.http.netty.common.Constants;
+import org.wso2.carbon.transport.http.netty.util.TestUtil;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A Message Processor class to be used for test transport security headers
+ */
+public class TransportSecurityHeadersProcessor implements CarbonMessageProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(TransportSecurityHeadersProcessor.class);
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    private ClientConnector clientConnector;
+
+    @Override
+    public boolean receive(CarbonMessage carbonMessage, CarbonCallback carbonCallback) throws Exception {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if (carbonMessage.getProperty(org.wso2.carbon.messaging.Constants.DIRECTION) != null
+                            && carbonMessage.getProperty(org.wso2.carbon.messaging.Constants.DIRECTION)
+                            .equals(org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE)) {
+                        carbonCallback.done(carbonMessage);
+
+                    } else {
+                        carbonMessage.setProperty(Constants.HOST, TestUtil.TEST_HOST);
+                        carbonMessage.setProperty(Constants.PORT, TestUtil.TEST_SERVER_PORT);
+                        clientConnector.send(carbonMessage, carbonCallback);
+                    }
+                } catch (ClientConnectorException e) {
+                    logger.error("MessageProcessor is not supported ", e);
+                }
+            }
+        });
+
+        return true;
+    }
+
+    @Override
+    public void setTransportSender(TransportSender transportSender) {
+    }
+
+    @Override
+    public void setClientConnector(ClientConnector clientConnector) {
+        this.clientConnector = clientConnector;
+    }
+
+    @Override
+    public String getId() {
+        return "security";
+    }
+
+}

--- a/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/security/TransportSecurityHeadersTestCase.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/security/TransportSecurityHeadersTestCase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.transport.http.netty.security;
+
+import io.netty.handler.codec.http.HttpMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.messaging.CarbonMessageProcessor;
+import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.carbon.transport.http.netty.config.ConfigurationBuilder;
+import org.wso2.carbon.transport.http.netty.config.TransportsConfiguration;
+import org.wso2.carbon.transport.http.netty.listener.HTTPServerConnector;
+import org.wso2.carbon.transport.http.netty.util.TestUtil;
+import org.wso2.carbon.transport.http.netty.util.server.HTTPServer;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.List;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.wso2.carbon.transport.http.netty.common.Constants.HTTP_PUBLIC_KEY_PINS_HEADER;
+import static org.wso2.carbon.transport.http.netty.common.Constants.HTTP_STRICT_TRANSPORT_SECURITY_HEADER;
+
+/**
+ * A test class for transport security headers
+ */
+public class TransportSecurityHeadersTestCase {
+
+    private List<HTTPServerConnector> serverConnectors;
+
+    private static final String hstsTestValue = "max-age=15768000; includeSubDomains";
+
+    private static final String hpkpTestValue = "pin-sha256='2pCcYrG90hDFxwOCsVya7wpbQjqhBy3OPsFyyT+7108=';" +
+            " max-age=15766000; includeSubDomains";
+    //the key used here is the public key of the default wso2carbon certificate.
+    private HTTPServer httpServer;
+
+    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 8490));
+
+    private CarbonMessageProcessor carbonMessageProcessor;
+
+    @BeforeClass
+    public void setUp() {
+        TransportsConfiguration configuration = ConfigurationBuilder.getInstance()
+                .getConfiguration("src/test/resources/simple-test-config/netty-transports.yml");
+        carbonMessageProcessor = new TransportSecurityHeadersProcessor();
+        serverConnectors = TestUtil.startConnectors(configuration, carbonMessageProcessor);
+        httpServer = TestUtil.startHTTPServer(TestUtil.TEST_SERVER_PORT);
+    }
+
+    @Test
+    public void hstsHeaderTest() {
+        try {
+            HttpURLConnection urlConn = TestUtil.request(baseURI, "/", HttpMethod.GET.name(), true);
+            String hstsHeader = urlConn.getHeaderField(HTTP_STRICT_TRANSPORT_SECURITY_HEADER);
+            assertEquals(hstsTestValue, hstsHeader);
+            urlConn.disconnect();
+        } catch (IOException e) {
+            TestUtil.handleException("IOException occurred while running hstsHeaderTest", e);
+        }
+    }
+
+    @Test
+    public void hpkpHeaderTest() {
+        try {
+            HttpURLConnection urlConn = TestUtil.request(baseURI, "/", HttpMethod.GET.name(), true);
+            String hpkpHeader = urlConn.getHeaderField(HTTP_PUBLIC_KEY_PINS_HEADER);
+            assertEquals(hpkpTestValue, hpkpHeader);
+            urlConn.disconnect();
+        } catch (IOException e) {
+            TestUtil.handleException("IOException occurred while running hpkpHeaderTest", e);
+        }
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        TestUtil.cleanUp(serverConnectors, httpServer);
+        TestUtil.removeMessageProcessor(carbonMessageProcessor);
+    }
+}

--- a/http/org.wso2.carbon.transport.http.netty/src/test/resources/testng.xml
+++ b/http/org.wso2.carbon.transport.http.netty/src/test/resources/testng.xml
@@ -21,6 +21,7 @@
 <suite name="Transport test Suite">
     <test name="Transport test">
         <classes>
+            <class name="org.wso2.carbon.transport.http.netty.security.TransportSecurityHeadersTestCase" />
             <class name="org.wso2.carbon.transport.http.netty.passthrough.PassThroughHttpTestCase" />
             <class name="org.wso2.carbon.transport.http.netty.contentaware.ContentAwareMessageProcessorTestCase" />
             <class name="org.wso2.carbon.transport.http.netty.http2.HTTP2RequestResponseTestCase" />


### PR DESCRIPTION
## Purpose
>Implementing HTTP Strict Transport Security and Public Key Pinning in carbon transports: Resolves [#394](https://github.com/wso2/carbon-transports/issues/394)

## Goals
> Making  HTTP Strict Transport Security and Public Key Pinning as configurable headers  in carbon transports.

## Approach
> Adding the header values configured in netty-transports.yml in to the HTTP response.

## User stories
> Users have to configure both HSTS and HPKP header values in netty-transports.yaml under listener configurations as follows.

 > id: "msf4j-https"
  ....
  scheme: https
  ....
  strictTransportSecurityHeader: <value> 
  publicKeyPinsHeader: <value>
   
   >The headers are added into the response only If the configuration values are not null and the listener 
  scheme is https. Configuration values in the netty-transport.yaml can be left blank if the headers are not 
  needed.

## Release note
>N/A

## Documentation
>N/A

## Training
> N/A

## Certification
> N/A

## Marketing
>N/A
## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > Available

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
>  N/A

## Migrations (if applicable)
>  N/A

## Test environment
>  N/A
 
## Learning
> [1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
   [2] https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning
   [3] https://scotthelme.co.uk/hpkp-toolset/