### PR TITLE
Fix direcOutOfMemory issue during loadtest 

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/BlockingEntityCollector.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/BlockingEntityCollector.java
@@ -46,7 +46,6 @@ public class BlockingEntityCollector implements EntityCollector {
     private AtomicBoolean endOfMsgAdded;
     private AtomicBoolean isConsumed;
     private BlockingQueue<HttpContent> httpContentQueue;
-//    private BlockingQueue<HttpContent> garbageCollected;
 
     public BlockingEntityCollector(int soTimeOut) {
         this.soTimeOut = soTimeOut;
@@ -54,7 +53,6 @@ public class BlockingEntityCollector implements EntityCollector {
         this.endOfMsgAdded = new AtomicBoolean(false);
         this.isConsumed = new AtomicBoolean(false);
         this.httpContentQueue = new LinkedBlockingQueue<>();
-//        this.garbageCollected = new LinkedBlockingQueue<>();
     }
 
     public void addHttpContent(HttpContent httpContent) {
@@ -73,9 +71,6 @@ public class BlockingEntityCollector implements EntityCollector {
             } else {
                 if (!isConsumed.get()) {
                     HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
-//                    if (httpContent != null) {
-//                        garbageCollected.add(httpContent);
-//                    }
 
                     if (httpContent instanceof LastHttpContent) {
                         isConsumed.set(true);
@@ -104,8 +99,6 @@ public class BlockingEntityCollector implements EntityCollector {
                     HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
                     if (httpContent != null) {
                         ByteBuf buf = httpContent.content();
-//                        garbageCollected.add(httpContent);
-
                         if (httpContent instanceof LastHttpContent) {
                             this.endOfMsgAdded.set(true);
                             isConsumed.set(true);
@@ -145,7 +138,6 @@ public class BlockingEntityCollector implements EntityCollector {
                             isConsumed.set(true);
                         }
                         ByteBuf buf = httpContent.content();
-//                        garbageCollected.add(httpContent);
                         byteBufferList.add(buf.nioBuffer());
                     } catch (InterruptedException e) {
                         LOG.error("Error while getting full message body", e);
@@ -230,10 +222,8 @@ public class BlockingEntityCollector implements EntityCollector {
         this.endOfMsgAdded.compareAndSet(false, endOfMsgAdded);
     }
 
+    @Deprecated
     public synchronized void release() {
-//        while (!garbageCollected.isEmpty()) {
-//            ReferenceCountUtil.release(garbageCollected.poll());
-//        }
     }
 
     // TODO: Need to move below two to ballarina code

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/BlockingEntityCollector.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/BlockingEntityCollector.java
@@ -23,7 +23,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +46,7 @@ public class BlockingEntityCollector implements EntityCollector {
     private AtomicBoolean endOfMsgAdded;
     private AtomicBoolean isConsumed;
     private BlockingQueue<HttpContent> httpContentQueue;
-    private BlockingQueue<HttpContent> garbageCollected;
+//    private BlockingQueue<HttpContent> garbageCollected;
 
     public BlockingEntityCollector(int soTimeOut) {
         this.soTimeOut = soTimeOut;
@@ -55,7 +54,7 @@ public class BlockingEntityCollector implements EntityCollector {
         this.endOfMsgAdded = new AtomicBoolean(false);
         this.isConsumed = new AtomicBoolean(false);
         this.httpContentQueue = new LinkedBlockingQueue<>();
-        this.garbageCollected = new LinkedBlockingQueue<>();
+//        this.garbageCollected = new LinkedBlockingQueue<>();
     }
 
     public void addHttpContent(HttpContent httpContent) {
@@ -74,9 +73,9 @@ public class BlockingEntityCollector implements EntityCollector {
             } else {
                 if (!isConsumed.get()) {
                     HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
-                    if (httpContent != null) {
-                        garbageCollected.add(httpContent);
-                    }
+//                    if (httpContent != null) {
+//                        garbageCollected.add(httpContent);
+//                    }
 
                     if (httpContent instanceof LastHttpContent) {
                         isConsumed.set(true);
@@ -96,7 +95,7 @@ public class BlockingEntityCollector implements EntityCollector {
         httpContentQueue.add(new DefaultHttpContent(Unpooled.copiedBuffer(msgBody)));
     }
 
-    public ByteBuffer getMessageBody() {
+    public ByteBuf getMessageBody() {
         try {
             if (isEndOfMsgAdded() && isEmpty()) {
                 isConsumed.set(true);
@@ -105,14 +104,14 @@ public class BlockingEntityCollector implements EntityCollector {
                     HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
                     if (httpContent != null) {
                         ByteBuf buf = httpContent.content();
-                        garbageCollected.add(httpContent);
+//                        garbageCollected.add(httpContent);
 
                         if (httpContent instanceof LastHttpContent) {
                             this.endOfMsgAdded.set(true);
                             isConsumed.set(true);
                         }
 
-                        return buf.nioBuffer();
+                        return buf;
                     }
                 }
             }
@@ -122,6 +121,7 @@ public class BlockingEntityCollector implements EntityCollector {
         return null;
     }
 
+    @Deprecated
     public List<ByteBuffer> getFullMessageBody() {
         List<ByteBuffer> byteBufferList = new ArrayList<>();
 
@@ -145,7 +145,7 @@ public class BlockingEntityCollector implements EntityCollector {
                             isConsumed.set(true);
                         }
                         ByteBuf buf = httpContent.content();
-                        garbageCollected.add(httpContent);
+//                        garbageCollected.add(httpContent);
                         byteBufferList.add(buf.nioBuffer());
                     } catch (InterruptedException e) {
                         LOG.error("Error while getting full message body", e);
@@ -155,6 +155,35 @@ public class BlockingEntityCollector implements EntityCollector {
         }
 
         return byteBufferList;
+    }
+
+    public void waitAndReleaseAllEntities() {
+        if (isEndOfMsgAdded() && isEmpty()) {
+            isConsumed.set(true);
+        } else {
+            if (!isConsumed.get()) {
+                boolean isEndOfMessageProcessed = false;
+                while (!isEndOfMessageProcessed) {
+                    try {
+                        HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
+                        // This check is to make sure we add the last http content after getClone and avoid adding
+                        // empty content to bytebuf list again and again
+                        if (httpContent instanceof EmptyLastHttpContent) {
+                            break;
+                        }
+
+                        if (httpContent instanceof LastHttpContent) {
+                            isEndOfMessageProcessed = true;
+                            isConsumed.set(true);
+                        }
+                        httpContent.release();
+                    } catch (InterruptedException e) {
+                        LOG.error("Error while getting full message body", e);
+                    }
+                }
+                setEndOfMsgAdded(true);
+            }
+        }
     }
 
     public int getFullMessageLength() {
@@ -202,9 +231,9 @@ public class BlockingEntityCollector implements EntityCollector {
     }
 
     public synchronized void release() {
-        while (!garbageCollected.isEmpty()) {
-            ReferenceCountUtil.release(garbageCollected.poll());
-        }
+//        while (!garbageCollected.isEmpty()) {
+//            ReferenceCountUtil.release(garbageCollected.poll());
+//        }
     }
 
     // TODO: Need to move below two to ballarina code

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/EntityCollector.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/EntityCollector.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.transport.http.netty.message;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpContent;
 
 import java.nio.ByteBuffer;
@@ -44,7 +45,7 @@ public interface EntityCollector {
      * Get the first ByteBuffer version of the HttpContent from the queue.
      * @return ByteBuffer
      */
-    ByteBuffer getMessageBody();
+    ByteBuf getMessageBody();
 
     /**
      * Add the ByteBuffer version the httpContent to the queue.
@@ -103,4 +104,9 @@ public interface EntityCollector {
      * @param alreadyRead indicated using true or false
      */
     void setAlreadyRead(boolean alreadyRead);
+
+    /**
+     * This is need to release content before GC
+     */
+    void waitAndReleaseAllEntities();
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/HTTPCarbonMessage.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.transport.http.netty.message;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.DefaultHttpRequest;
@@ -77,7 +78,7 @@ public class HTTPCarbonMessage {
         return blockingEntityCollector.getHttpContent();
     }
 
-    public ByteBuffer getMessageBody() {
+    public ByteBuf getMessageBody() {
         return blockingEntityCollector.getMessageBody();
     }
 
@@ -277,6 +278,10 @@ public class HTTPCarbonMessage {
         fullMessageBody.forEach(this::addMessageBody);
         markMessageEnd();
         return newCopy;
+    }
+
+    public void waitAndReleaseAllEntities() {
+        blockingEntityCollector.waitAndReleaseAllEntities();
     }
 
     @Override

--- a/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/contentaware/ResponseStreamingWithoutBufferingListener.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/test/java/org/wso2/carbon/transport/http/netty/contentaware/ResponseStreamingWithoutBufferingListener.java
@@ -58,7 +58,7 @@ public class ResponseStreamingWithoutBufferingListener implements HttpConnectorL
                 }
             });
             while (!(httpRequestMessage.isEmpty() && httpRequestMessage.isEndOfMsgAdded())) {
-                cMsg.addMessageBody(httpRequestMessage.getMessageBody());
+                cMsg.addMessageBody(httpRequestMessage.getMessageBody().nioBuffer());
             }
             cMsg.setEndOfMsgAdded(true);
             httpRequestMessage.release();


### PR DESCRIPTION
## Purpose
> Ballerina goes out of memory during the load test when there are code snippets that requires reading stream. This has been fixed in this PR.

## Goals
> Previously we used to collect the content and then later release it. Now we have changed it to release then and there.

## Approach
> Releasing the content then there. Rather than collecting it and releasing it later.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 N/A

## Security checks
Yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A