### PR TITLE
Fix the hanging issue of waitAndReleaseAllEntities()

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/BlockingEntityCollector.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/BlockingEntityCollector.java
@@ -67,11 +67,12 @@ public class BlockingEntityCollector implements EntityCollector {
 
     public HttpContent getHttpContent() {
         try {
-            if (!isConsumed.get()) {
+            if (!isConsumed.get() || !alreadyRead.get()) {
                 HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
 
                 if (httpContent instanceof LastHttpContent) {
                     isConsumed.set(true);
+                    alreadyRead.set(false);
                     httpContentQueue.clear();
                 }
 
@@ -128,7 +129,7 @@ public class BlockingEntityCollector implements EntityCollector {
     }
 
     public void waitAndReleaseAllEntities() {
-        if (!isConsumed.get()) {
+        if (!isConsumed.get() && !alreadyRead.get()) {
             boolean isEndOfMessageProcessed = false;
             while (!isEndOfMessageProcessed) {
                 try {
@@ -141,7 +142,7 @@ public class BlockingEntityCollector implements EntityCollector {
 
                     if (httpContent instanceof LastHttpContent) {
                         isEndOfMessageProcessed = true;
-                        isConsumed.set(false);
+                        isConsumed.set(true);
                     }
                     httpContent.release();
                 } catch (InterruptedException e) {


### PR DESCRIPTION
## Purpose
> Fixing the blocking issue of waitAndReleaseAllEntities()

## Goals
> Avoid thread hanging. 

## Approach
> Adding a new state.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
Covered by existing tests.

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A