### PR TITLE
Upgrade netty version to 4.1.16-Final

### DIFF
--- a/connector-framework/pom.xml
+++ b/connector-framework/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/email/org.wso2.carbon.transport.email/pom.xml
+++ b/email/org.wso2.carbon.transport.email/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.email.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/email/pom.xml
+++ b/email/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/connector-framework/pom.xml
+++ b/features/connector-framework/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.feature.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/email/org.wso2.carbon.transport.email.feature/pom.xml
+++ b/features/email/org.wso2.carbon.transport.email.feature/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.email.feature.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/email/pom.xml
+++ b/features/email/pom.xml
@@ -19,7 +19,7 @@
         <artifactId>org.wso2.carbon.transport.feature.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>  
         <relativePath>../pom.xml</relativePath>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/features/file/org.wso2.carbon.transport.file.feature/pom.xml
+++ b/features/file/org.wso2.carbon.transport.file.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.file.feature.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/file/pom.xml
+++ b/features/file/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.feature.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/features/http/org.wso2.carbon.transport.http.netty.feature/pom.xml
+++ b/features/http/org.wso2.carbon.transport.http.netty.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.http.feature.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/http/org.wso2.carbon.transport.http.netty.statistics.feature/pom.xml
+++ b/features/http/org.wso2.carbon.transport.http.netty.statistics.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.http.feature.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/http/pom.xml
+++ b/features/http/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.feature.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/jms/org.wso2.carbon.transport.jms.feature/pom.xml
+++ b/features/jms/org.wso2.carbon.transport.jms.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.jms.feature.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/jms/pom.xml
+++ b/features/jms/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.feature.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/file/org.wso2.carbon.transport.file-system/pom.xml
+++ b/file/org.wso2.carbon.transport.file-system/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.carbon.transport</groupId>
         <artifactId>org.wso2.carbon.transport.file.parent</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/file/org.wso2.carbon.transport.file/pom.xml
+++ b/file/org.wso2.carbon.transport.file/pom.xml
@@ -23,7 +23,7 @@
 <parent>
         <groupId>org.wso2.carbon.transport</groupId>
         <artifactId>org.wso2.carbon.transport.file.parent</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/file/pom.xml
+++ b/file/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/http/org.wso2.carbon.transport.http.netty.statistics/pom.xml
+++ b/http/org.wso2.carbon.transport.http.netty.statistics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.transport</groupId>
         <artifactId>org.wso2.carbon.transport.http.parent</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/http/org.wso2.carbon.transport.http.netty/pom.xml
+++ b/http/org.wso2.carbon.transport.http.netty/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.transport</groupId>
         <artifactId>org.wso2.carbon.transport.http.parent</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -33,7 +33,7 @@
         <url>https://github.com/wso2/carbon-transports.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-transports.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-transports.git</connection>
-        <tag>v5.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencies>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jms/org.wso2.carbon.transport.jms/pom.xml
+++ b/jms/org.wso2.carbon.transport.jms/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.jms.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jms/pom.xml
+++ b/jms/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.transport.parent</artifactId>
         <groupId>org.wso2.carbon.transport</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
 
         <carbon.utils.version>2.0.2</carbon.utils.version>
-        <netty.version>4.1.7.Final</netty.version>
+        <netty.version>4.1.16.Final</netty.version>
         <netty.package.import.version.range>[4.0.30, 5.0.0)</netty.package.import.version.range>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
     <groupId>org.wso2.carbon.transport</groupId>
     <artifactId>org.wso2.carbon.transport.parent</artifactId>
-    <version>5.0.1</version>
+    <version>5.0.2-SNAPSHOT</version>
     <name>WSO2 Carbon Transport Parent</name>
 
     <modules>
@@ -41,7 +41,7 @@
         <url>https://github.com/wso2/carbon-transports.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-transports.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-transports.git</connection>
-        <tag>v5.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 


### PR DESCRIPTION
## Purpose
Prepare 5.0.x branch for 5.0.2 release and upgrade netty version to 4.1.16-Final

## Goals
This is for msf4j. we need to upgrade netty version to support gRPC framework

## Approach
Upgrade netty version from 4.1.7-Final to 4.1.16-Final

