### PR TITLE
Fix the issue of not re-setting the http carbon message state

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/message/HTTPCarbonMessage.java
@@ -361,4 +361,8 @@ public class HTTPCarbonMessage {
     public HttpContent peek() {
         return this.blockingEntityCollector.peek();
     }
+
+    public synchronized void removeHttpContentAsyncFuture() {
+        this.messageFuture = null;
+    }
 }

--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/TargetChannel.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/sender/channel/TargetChannel.java
@@ -160,6 +160,8 @@ public class TargetChannel {
                     this.channel.eventLoop().execute(() -> {
                 if (Util.isLastHttpContent(httpContent)) {
                     this.getChannel().writeAndFlush(httpContent);
+                    httpCarbonRequest.removeHttpContentAsyncFuture();
+
                     if (handlerExecutor != null) {
                         handlerExecutor.executeAtTargetRequestSending(httpCarbonRequest);
                     }


### PR DESCRIPTION
## Purpose
> Fix the issue of not re-setting the http carbon message state.

## Goals
> N/A

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
> N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A