### PR TITLE
Refactor HttpResponseStatusFuture sync method

### DIFF
--- a/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpResponseStatusFuture.java
+++ b/http/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpResponseStatusFuture.java
@@ -35,14 +35,6 @@ public class HttpResponseStatusFuture implements HttpResponseFuture {
     private Semaphore executionWaitSem;
 
     @Override
-    public void setHttpConnectorListener(HttpConnectorListener connectorListener) {
-    }
-
-    @Override
-    public void removeHttpListener() {
-    }
-
-    @Override
     public void notifyHttpListener(HTTPCarbonMessage httpCarbonMessage) {
         this.httpCarbonMessage = httpCarbonMessage;
         if (executionWaitSem != null) {
@@ -58,7 +50,7 @@ public class HttpResponseStatusFuture implements HttpResponseFuture {
         }
     }
 
-    public Throwable sync() throws InterruptedException {
+    public HttpResponseStatusFuture sync() throws InterruptedException {
         executionWaitSem = new Semaphore(0);
         if (this.httpCarbonMessage == null && this.throwable == null) {
             executionWaitSem.acquire();
@@ -71,6 +63,18 @@ public class HttpResponseStatusFuture implements HttpResponseFuture {
             status = throwable;
             throwable = null;
         }
+        return this;
+    }
+
+    public Throwable getStatus() {
         return status;
+    }
+
+    @Override
+    public void setHttpConnectorListener(HttpConnectorListener connectorListener) {
+    }
+
+    @Override
+    public void removeHttpListener() {
     }
 }


### PR DESCRIPTION
## Purpose
> Make HttpResponseStatusFuture sync method returns the future itself and add a seperate getter to get the status of the future.

## Goals
> N/A

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
>N/A

## Automation tests
 >N/A

## Security checks
 >N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A